### PR TITLE
Implement additional organism types

### DIFF
--- a/.project-management/tasks/current-tasks.md
+++ b/.project-management/tasks/current-tasks.md
@@ -21,6 +21,10 @@
 - `backend/main.py` - FastAPI application entry point
 - `backend/models/organism.py` - Base organism definition
 - `backend/tests/test_organism.py` - Unit tests for Organism
+- `backend/models/algae.py` - Algae organism implementation
+- `backend/models/herbivore.py` - Herbivore organism implementation
+- `backend/models/carnivore.py` - Carnivore organism implementation
+- `backend/tests/test_specific_organisms.py` - Unit tests for concrete organisms
 - `dev_init.sh` - Development startup script
 - `pytest.ini` - Pytest configuration
 - `frontend/src/dummy.js` - Placeholder script for linting
@@ -36,15 +40,15 @@
 
 ## Tasks
 
-- [ ] 1.0 Setup Backend Infrastructure and Core Models
+- [x] 1.0 Setup Backend Infrastructure and Core Models
   - [x] 1.1 Initialize FastAPI project structure with proper directory layout
   - [x] 1.2 Update requirements.txt with FastAPI, uvicorn, pydantic, and testing dependencies
   - [x] 1.3 Create base Organism abstract class with core properties (position, size, energy, nutrients)
   - [x] 1.4 Implement Organism base methods (move, grow, reproduce, die, consume_nutrients)
-  - [ ] 1.5 Create Algae class inheriting from Organism with stationary growth behavior
-  - [ ] 1.6 Create Herbivore class inheriting from Organism with movement and algae consumption
-  - [ ] 1.7 Create Carnivore class inheriting from Organism with movement and herbivore hunting
-  - [ ] 1.8 Write unit tests for all organism classes and their behaviors
+  - [x] 1.5 Create Algae class inheriting from Organism with stationary growth behavior
+  - [x] 1.6 Create Herbivore class inheriting from Organism with movement and algae consumption
+  - [x] 1.7 Create Carnivore class inheriting from Organism with movement and herbivore hunting
+  - [x] 1.8 Write unit tests for all organism classes and their behaviors
   - [x] 1.9 Set up pytest configuration and test directory structure
 
 - [ ] 2.0 Implement Simulation Engine and Environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 2025-06-03 Initialized FastAPI backend structure and base organism class
 2025-06-03 Implemented base Organism behaviors
+2025-06-03 Added Algae, Herbivore, and Carnivore models with tests

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,11 @@
+from .organism import Organism
+from .algae import Algae
+from .herbivore import Herbivore
+from .carnivore import Carnivore
+
+__all__ = [
+    "Organism",
+    "Algae",
+    "Herbivore",
+    "Carnivore",
+]

--- a/backend/models/algae.py
+++ b/backend/models/algae.py
@@ -1,0 +1,8 @@
+from .organism import Organism
+
+
+class Algae(Organism):
+    """Stationary organism that only grows."""
+
+    def move(self) -> None:  # pragma: no cover - intentionally does nothing
+        pass

--- a/backend/models/carnivore.py
+++ b/backend/models/carnivore.py
@@ -1,0 +1,15 @@
+from .herbivore import Herbivore
+from .organism import Organism
+
+
+class Carnivore(Organism):
+    """Organism that hunts herbivores."""
+
+    def move(self) -> None:
+        x, y = self.position
+        self.position = (x + 1, y)
+        self.energy -= 0.2
+
+    def hunt(self, herbivore: Herbivore) -> None:
+        self.consume_nutrients(herbivore.energy)
+        herbivore.energy = 0

--- a/backend/models/herbivore.py
+++ b/backend/models/herbivore.py
@@ -1,0 +1,15 @@
+from .algae import Algae
+from .organism import Organism
+
+
+class Herbivore(Organism):
+    """Organism that moves and consumes algae."""
+
+    def move(self) -> None:
+        x, y = self.position
+        self.position = (x + 1, y)
+        self.energy -= 0.1
+
+    def eat(self, algae: Algae) -> None:
+        self.consume_nutrients(algae.energy)
+        algae.energy = 0

--- a/backend/tests/test_specific_organisms.py
+++ b/backend/tests/test_specific_organisms.py
@@ -1,0 +1,28 @@
+from backend.models import Algae, Herbivore, Carnivore
+
+
+def test_algae_growth():
+    algae = Algae((0, 0), size=1.0, energy=0.0, nutrients=2.0)
+    algae.grow()
+    assert algae.size > 1.0
+    assert algae.nutrients < 2.0
+
+
+def test_herbivore_move_and_eat():
+    algae = Algae((0, 0), size=1.0, energy=1.0, nutrients=0.0)
+    herbivore = Herbivore((0, 0), size=1.0, energy=0.0, nutrients=0.0)
+    herbivore.move()
+    assert herbivore.position == (1, 0)
+    herbivore.eat(algae)
+    assert herbivore.energy > 0.0
+    assert algae.energy == 0
+
+
+def test_carnivore_move_and_hunt():
+    herbivore = Herbivore((0, 0), size=1.0, energy=1.0, nutrients=0.0)
+    carnivore = Carnivore((0, 0), size=1.0, energy=0.0, nutrients=0.0)
+    carnivore.move()
+    assert carnivore.position == (1, 0)
+    carnivore.hunt(herbivore)
+    assert carnivore.energy > 0.0
+    assert herbivore.energy == 0


### PR DESCRIPTION
## Summary
- add Algae, Herbivore and Carnivore models
- export new models from backend.models
- add unit tests for new organisms
- update task list and changelog

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683ea99d4c4c833181ce450be676f304