### PR TITLE
Add PRD for EcoSim simulator

### DIFF
--- a/.project-management/tasks/prd-ecosim.md
+++ b/.project-management/tasks/prd-ecosim.md
@@ -1,0 +1,44 @@
+## 1. Introduction/Overview
+"EcoSim Circle of Life" is a simple web-based ecosystem simulator consisting of three organism types: Algae, Herbivores, and Carnivores. The goal is to provide an interactive environment where a single user can start, stop, and tweak simulation parameters without requiring logins or data persistence. All settings reset when the app reloads.
+
+## 2. Goals
+- Allow a single user to run the simulation and adjust parameters via a dashboard.
+- Visually display organisms in a 2D environment and show text-based statistics for populations and nutrients.
+- Maintain acceptable performance as organism counts grow (aim for smooth updates).
+
+## 3. User Stories
+1. **As a user**, I want to start or stop the simulation so that I can observe the ecosystem evolve.
+2. **As a user**, I want to modify parameters such as initial populations or reproduction thresholds so that I can experiment with different scenarios.
+3. **As a user**, I want to view counts of Algae, Herbivores, Carnivores, and total nutrients so that I understand how the simulation is progressing.
+
+## 4. Functional Requirements
+1. The system must provide REST endpoints to start, stop, step, and reset the simulation.
+2. The system must provide an endpoint to fetch the current state of all organisms for rendering.
+3. The system must provide endpoints to get and update simulation parameters.
+4. The frontend must render organisms in a 2D canvas or SVG using data from the `/simulation/state` endpoint.
+5. The frontend must display text-based statistics showing current organism counts and nutrient levels.
+6. All interface elements should follow the layout and style defined in `.project-management/prd-background/PrototypeDesign.html`.
+
+## 5. Non-Goals (Out of Scope)
+- User authentication or multiple user accounts.
+- Persistence of simulation state across sessions.
+- Exporting or importing simulation data.
+- Graphical charts; statistics will be text only.
+
+## 6. Design Considerations
+- Follow the visual layout in `.project-management/prd-background/PrototypeDesign.html` for the dashboard and display area.
+- Keep the UI minimal: start/stop buttons, parameter controls, and a panel with text statistics.
+
+## 7. Technical Considerations
+- Backend implemented with FastAPI and Python.
+- Frontend built with React and Vite.
+- Communication through JSON-based REST endpoints (consider WebSockets later for real-time updates).
+- Performance should remain acceptable with a moderately large number of organisms; computation occurs primarily on the backend.
+
+## 8. Success Metrics
+- The simulation runs smoothly with typical settings (e.g., hundreds of organisms) without noticeable lag.
+- Users can adjust parameters and see changes reflected in the simulation state and statistics.
+
+## 9. Open Questions
+- What is the maximum expected organism count for the initial MVP?
+- Should WebSocket-based state updates be explored in a later iteration?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+2025-06-03 Added PRD for EcoSim Circle of Life
+
+  - run_tests.sh failed: backend/tests missing


### PR DESCRIPTION
## Summary
- generate product requirements document for EcoSim simulator
- log run_tests issue in CHANGELOG

## Testing
- `flake8`
- `npm run lint`
- `bash run_tests.sh` *(fails: backend/tests missing)*

------
https://chatgpt.com/codex/tasks/task_e_683eb1fc3b948331ad9a40699da8d58e