### PR TITLE
Implement spawn logic and simulation API

### DIFF
--- a/.project-management/tasks/current-tasks.md
+++ b/.project-management/tasks/current-tasks.md
@@ -31,6 +31,8 @@
 - `backend/tests/test_simulation_engine.py` - Unit tests for simulation engine
 - `backend/tests/test_main.py` - Unit tests for FastAPI root endpoint
 - `backend/tests/test_collision_detection.py` - Unit tests for collision logic
+- `backend/api/simulation.py` - API endpoints for simulation control
+- `backend/tests/test_api.py` - Integration tests for simulation API
 - `dev_init.sh` - Development startup script
 - `pytest.ini` - Pytest configuration
 - `frontend/src/dummy.js` - Placeholder script for linting
@@ -62,7 +64,7 @@
   - [x] 2.2 Implement nutrient distribution and tracking system within environment
   - [x] 2.3 Create SimulationEngine class to manage organism collections and time steps
   - [x] 2.4 Implement collision detection for organism interactions (eating, reproduction)
-  - [ ] 2.5 Add organism spawning logic with configurable initial populations
+  - [x] 2.5 Add organism spawning logic with configurable initial populations
   - [ ] 2.6 Implement energy costs for movement and growth calculations
   - [ ] 2.7 Add reproduction mechanics when organisms reach size/energy thresholds
   - [ ] 2.8 Implement death conditions and nutrient release back to environment
@@ -71,10 +73,10 @@
 
 - [ ] 3.0 Create API Endpoints for Simulation Control
   - [x] 3.1 Set up FastAPI main application with CORS middleware for frontend
-  - [ ] 3.2 Create /simulation/reset endpoint to initialize simulation with default parameters
-  - [ ] 3.3 Create /simulation/step endpoint to advance simulation by one time step
-  - [ ] 3.4 Create /simulation/state endpoint returning organism positions, sizes, and types
-  - [ ] 3.5 Create /stats endpoint returning population counts and simulation step number
+  - [x] 3.2 Create /simulation/reset endpoint to initialize simulation with default parameters
+  - [x] 3.3 Create /simulation/step endpoint to advance simulation by one time step
+  - [x] 3.4 Create /simulation/state endpoint returning organism positions, sizes, and types
+  - [x] 3.5 Create /stats endpoint returning population counts and simulation step number
   - [ ] 3.6 Implement proper error handling and HTTP status codes for all endpoints
   - [ ] 3.7 Add request/response models using Pydantic for type safety
   - [ ] 3.8 Write integration tests for all API endpoints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 2025-06-03 Added Environment and SimulationEngine with tests
 2025-06-03 Added CORS middleware and root endpoint test
 2025-06-04 Implemented organism collision detection with tests
+2025-06-05 Added simulation spawn logic and basic API endpoints

--- a/backend/api/simulation.py
+++ b/backend/api/simulation.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter
+
+from backend.simulation.engine import SimulationEngine
+
+router = APIRouter()
+
+# Global engine instance used by API endpoints
+engine = SimulationEngine()
+
+
+@router.post("/reset")
+def reset_simulation(algae: int = 10, herbivores: int = 5, carnivores: int = 2):
+    """Reset simulation with default populations."""
+    engine.reset(algae, herbivores, carnivores)
+    return {"status": "reset", "organisms": len(engine.organisms)}
+
+
+@router.post("/step")
+def step_simulation():
+    """Advance the simulation by one step."""
+    engine.step()
+    return {"step": engine.step_count}
+
+
+@router.get("/state")
+def state_simulation():
+    """Return current simulation state."""
+    organisms = [
+        {
+            "type": o.__class__.__name__.lower(),
+            "position": o.position,
+            "size": o.size,
+            "energy": o.energy,
+        }
+        for o in engine.organisms
+    ]
+    return {"step": engine.step_count, "organisms": organisms}
+
+
+@router.get("/stats")
+def simulation_stats():
+    """Return population counts and current step."""
+    from collections import Counter
+
+    counts = Counter(o.__class__.__name__.lower() for o in engine.organisms)
+    return {"step": engine.step_count, "counts": counts}

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@ import os
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from backend.api.simulation import router as simulation_router
 
 app = FastAPI(title="Ecosystem Simulation API")
 
@@ -14,6 +15,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.include_router(simulation_router, prefix="/simulation")
 
 
 @app.get("/")

--- a/backend/simulation/engine.py
+++ b/backend/simulation/engine.py
@@ -17,6 +17,29 @@ class SimulationEngine:
     def add_organism(self, organism: Organism) -> None:
         self.organisms.append(organism)
 
+    def spawn(self, algae: int = 0, herbivores: int = 0, carnivores: int = 0) -> None:
+        """Spawn a mix of organisms with default attributes."""
+        from random import randint
+
+        def random_position() -> tuple[int, int]:
+            return (
+                randint(0, self.environment.width - 1),
+                randint(0, self.environment.height - 1),
+            )
+
+        for _ in range(algae):
+            self.add_organism(Algae(random_position(), 1.0, 1.0, 1.0))
+        for _ in range(herbivores):
+            self.add_organism(Herbivore(random_position(), 1.0, 1.0, 1.0))
+        for _ in range(carnivores):
+            self.add_organism(Carnivore(random_position(), 1.0, 1.0, 1.0))
+
+    def reset(self, algae: int = 10, herbivores: int = 5, carnivores: int = 2) -> None:
+        """Reset the simulation and spawn new organisms."""
+        self.organisms = []
+        self.step_count = 0
+        self.spawn(algae, herbivores, carnivores)
+
     def step(self) -> None:
         """Advance the simulation by one step."""
         new_organisms: List[Organism] = []

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,27 @@
+from fastapi.testclient import TestClient
+from backend.main import app
+
+
+def test_simulation_endpoints():
+    client = TestClient(app)
+
+    params = {"algae": 1, "herbivores": 0, "carnivores": 0}
+    resp = client.post("/simulation/reset", params=params)
+    assert resp.status_code == 200
+    assert resp.json()["organisms"] == 1
+
+    resp = client.post("/simulation/step")
+    assert resp.status_code == 200
+    assert resp.json()["step"] == 1
+
+    resp = client.get("/simulation/state")
+    assert resp.status_code == 200
+    state = resp.json()
+    assert state["step"] == 1
+    assert len(state["organisms"]) >= 1
+
+    resp = client.get("/simulation/stats")
+    assert resp.status_code == 200
+    stats = resp.json()
+    assert stats["step"] == 1
+    assert stats["counts"]["algae"] >= 1

--- a/backend/tests/test_simulation_engine.py
+++ b/backend/tests/test_simulation_engine.py
@@ -23,3 +23,13 @@ def test_engine_step_increments_counter():
     engine.step()
     assert engine.step_count == 1
     assert len(engine.organisms) == 1
+
+
+def test_spawn_and_reset():
+    engine = SimulationEngine()
+    engine.spawn(algae=2, herbivores=1, carnivores=1)
+    assert len(engine.organisms) == 4
+
+    engine.reset(algae=1, herbivores=0, carnivores=0)
+    assert len(engine.organisms) == 1
+    assert engine.step_count == 0


### PR DESCRIPTION
## Summary
- add spawn and reset logic in `SimulationEngine`
- expose new API endpoints in `backend/api/simulation.py`
- wire router in `backend/main.py`
- test engine spawn/reset and API endpoints
- document changes in tasks and changelog

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683eb3f3e91c8331bf09080bd1b9ddab