### PR TITLE
Implement reproduction thresholds and nutrient recycling

### DIFF
--- a/.project-management/tasks/current-tasks.md
+++ b/.project-management/tasks/current-tasks.md
@@ -32,6 +32,7 @@
 - `backend/tests/test_simulation_engine.py` - Unit tests for simulation engine
 - `backend/tests/test_main.py` - Unit tests for FastAPI root endpoint
 - `backend/tests/test_collision_detection.py` - Unit tests for collision logic
+- `backend/tests/test_reproduction_and_death.py` - Unit tests for reproduction and nutrient release
 - `backend/api/simulation.py` - API endpoints for simulation control
 - `backend/tests/test_api.py` - Integration tests for simulation API
 - `dev_init.sh` - Development startup script
@@ -66,9 +67,9 @@
   - [x] 2.3 Create SimulationEngine class to manage organism collections and time steps
   - [x] 2.4 Implement collision detection for organism interactions (eating, reproduction)
   - [x] 2.5 Add organism spawning logic with configurable initial populations
-  - [c] 2.6 Implement energy costs for movement and growth calculations
-  - [ ] 2.7 Add reproduction mechanics when organisms reach size/energy thresholds
-  - [ ] 2.8 Implement death conditions and nutrient release back to environment
+  - [x] 2.6 Implement energy costs for movement and growth calculations
+  - [x] 2.7 Add reproduction mechanics when organisms reach size/energy thresholds
+  - [x] 2.8 Implement death conditions and nutrient release back to environment
   - [ ] 2.9 Add boundary handling (wrap-around or collision with walls)
   - [ ] 2.10 Write comprehensive unit tests for simulation engine and environment
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 2025-06-04 Implemented organism collision detection with tests
 2025-06-05 Added simulation spawn logic and basic API endpoints
 2025-06-05 Added energy cost to organism growth
+2025-06-05 Added reproduction thresholds and nutrient release on death

--- a/backend/models/organism.py
+++ b/backend/models/organism.py
@@ -36,14 +36,14 @@ class Organism(ABC):
             self.size += consumed
 
     def reproduce(self) -> Optional["Organism"]:
-        """Create a new organism if energy allows.
+        """Create a new organism if energy and size allow.
 
-        Returns a new organism instance with half the parent's energy
-        and nutrients, or ``None`` if reproduction conditions are not
-        met.
+        Offspring inherits half the parent's size, energy, and nutrients.
+        Returns ``None`` if thresholds are not met.
         """
-        if self.energy > 1.0:
+        if self.energy >= 2.0 and self.size >= 2.0:
             self.energy /= 2
+            self.size /= 2
             offspring = self.__class__(
                 position=self.position,
                 size=self.size,

--- a/backend/simulation/engine.py
+++ b/backend/simulation/engine.py
@@ -66,6 +66,11 @@ class SimulationEngine:
             if offspring is not None:
                 new_organisms.append(offspring)
             if organism.die():
+                # return remaining energy and nutrients to the environment
+                self.environment.add_nutrients(
+                    organism.position,
+                    organism.energy + organism.nutrients,
+                )
                 self.organisms.remove(organism)
 
         self.organisms.extend(new_organisms)

--- a/backend/tests/test_reproduction_and_death.py
+++ b/backend/tests/test_reproduction_and_death.py
@@ -1,0 +1,24 @@
+from backend.models.organism import Organism
+from backend.simulation.engine import SimulationEngine
+from backend.models import Algae, Herbivore
+
+
+def test_reproduction_thresholds():
+    org = Organism((0, 0), size=2.0, energy=2.0, nutrients=0.0)
+    child = org.reproduce()
+    assert child is not None
+    assert org.size == 1.0
+    assert child.size == 1.0
+    assert org.energy == 1.0
+    assert child.energy == 1.0
+
+
+def test_nutrient_release_on_death():
+    engine = SimulationEngine()
+    algae = Algae((1, 1), size=1.0, energy=1.0, nutrients=2.0)
+    herbivore = Herbivore((0, 1), size=1.0, energy=0.0, nutrients=0.0)
+    engine.add_organism(algae)
+    engine.add_organism(herbivore)
+    engine.step()
+    assert all(not isinstance(o, Algae) for o in engine.organisms)
+    assert engine.environment.get_nutrients((1, 1)) == 1.0


### PR DESCRIPTION
## Summary
- add reproduction size/energy thresholds to Organism
- recycle nutrients to environment when organisms die
- cover new logic with reproduction and death tests
- update tasks for completed work and changelog

## Testing
- `flake8`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683ebbce3774833190667beff96e7e5b