### PR TITLE
Implement boundary wraparound

### DIFF
--- a/.project-management/tasks/current-tasks.md
+++ b/.project-management/tasks/current-tasks.md
@@ -30,6 +30,7 @@
 - `backend/simulation/engine.py` - Simulation engine orchestrating organisms
 - `backend/tests/test_environment.py` - Unit tests for environment
 - `backend/tests/test_simulation_engine.py` - Unit tests for simulation engine
+- `backend/tests/test_boundary_handling.py` - Unit tests for environment boundary handling
 - `backend/tests/test_main.py` - Unit tests for FastAPI root endpoint
 - `backend/tests/test_collision_detection.py` - Unit tests for collision logic
 - `backend/tests/test_reproduction_and_death.py` - Unit tests for reproduction and nutrient release
@@ -70,8 +71,8 @@
   - [x] 2.6 Implement energy costs for movement and growth calculations
   - [x] 2.7 Add reproduction mechanics when organisms reach size/energy thresholds
   - [x] 2.8 Implement death conditions and nutrient release back to environment
-  - [ ] 2.9 Add boundary handling (wrap-around or collision with walls)
-  - [ ] 2.10 Write comprehensive unit tests for simulation engine and environment
+  - [c] 2.9 Add boundary handling (wrap-around or collision with walls)
+  - [c] 2.10 Write comprehensive unit tests for simulation engine and environment
 
 - [ ] 3.0 Create API Endpoints for Simulation Control
   - [x] 3.1 Set up FastAPI main application with CORS middleware for frontend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 2025-06-05 Added simulation spawn logic and basic API endpoints
 2025-06-05 Added energy cost to organism growth
 2025-06-05 Added reproduction thresholds and nutrient release on death
+2025-06-03 Added boundary handling with wrap-around and tests

--- a/backend/simulation/engine.py
+++ b/backend/simulation/engine.py
@@ -44,9 +44,10 @@ class SimulationEngine:
         """Advance the simulation by one step."""
         new_organisms: List[Organism] = []
 
-        # Move and grow all organisms first
+        # Move and grow all organisms first and enforce boundaries
         for organism in list(self.organisms):
             organism.move()
+            organism.position = self.environment.wrap_position(organism.position)
             organism.grow()
 
         # Handle collisions for eating interactions

--- a/backend/simulation/environment.py
+++ b/backend/simulation/environment.py
@@ -24,3 +24,8 @@ class Environment:
         if consumed:
             self._nutrients[position] = available - consumed
         return consumed
+
+    def wrap_position(self, position: Tuple[int, int]) -> Tuple[int, int]:
+        """Return position wrapped within environment bounds."""
+        x, y = position
+        return (x % self.width, y % self.height)

--- a/backend/tests/test_boundary_handling.py
+++ b/backend/tests/test_boundary_handling.py
@@ -1,0 +1,12 @@
+from backend.simulation.engine import SimulationEngine
+from backend.models import Herbivore
+from backend.simulation.environment import Environment
+
+
+def test_wrap_around_movement():
+    env = Environment(width=2, height=2)
+    engine = SimulationEngine(environment=env)
+    herb = Herbivore(position=(1, 1), size=1.0, energy=1.0, nutrients=0.0)
+    engine.add_organism(herb)
+    engine.step()
+    assert herb.position == (0, 1)


### PR DESCRIPTION
## Summary
- add environment.wrap_position for wrap-around boundaries
- adjust SimulationEngine.step to enforce boundaries
- test boundary handling with new test
- track new tests in task list and mark tasks committed
- document changes in CHANGELOG

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683ebcee4558833195296c3e04b9021a