### PR TITLE
Implement API docs and TypeScript setup

### DIFF
--- a/.project-management/tasks/current-tasks.md
+++ b/.project-management/tasks/current-tasks.md
@@ -41,6 +41,9 @@
 - `pytest.ini` - Pytest configuration
 - `frontend/src/dummy.js` - Placeholder script for linting
 - `frontend/src/index.tsx` - Placeholder React entry
+- `frontend/package.json` - Frontend dependencies and scripts
+- `frontend/tsconfig.json` - TypeScript configuration
+- `frontend/vite.config.ts` - Vite build configuration
 
 ### Notes
 
@@ -84,11 +87,11 @@
   - [x] 3.6 Implement proper error handling and HTTP status codes for all endpoints
   - [x] 3.7 Add request/response models using Pydantic for type safety
   - [x] 3.8 Write integration tests for all API endpoints
-  - [ ] 3.9 Add API documentation with proper OpenAPI/Swagger descriptions
+  - [x] 3.9 Add API documentation with proper OpenAPI/Swagger descriptions
 
 - [ ] 4.0 Build Frontend React Application
-  - [ ] 4.1 Initialize React project with Vite and TypeScript configuration
-  - [ ] 4.2 Update package.json with required dependencies (React, TypeScript, Canvas/SVG libraries)
+  - [x] 4.1 Initialize React project with Vite and TypeScript configuration
+  - [x] 4.2 Update package.json with required dependencies (React, TypeScript, Canvas/SVG libraries)
   - [ ] 4.3 Create main App component with layout matching PrototypeDesign.html structure
   - [ ] 4.4 Set up CSS variables and styling based on the provided design system
   - [ ] 4.5 Create TypeScript interfaces for simulation data (Organism, SimulationState, Stats)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 2025-06-05 Added reproduction thresholds and nutrient release on death
 2025-06-03 Added boundary handling with wrap-around and tests
 2025-06-03 Added Pydantic models and error handling for API endpoints
+2025-06-03 Added OpenAPI summaries and TypeScript frontend setup

--- a/backend/api/simulation.py
+++ b/backend/api/simulation.py
@@ -30,13 +30,18 @@ class StatsResponse(BaseModel):
     counts: dict[str, int]
 
 
-router = APIRouter()
+router = APIRouter(tags=["Simulation"])
 
 # Global engine instance used by API endpoints
 engine = SimulationEngine()
 
 
-@router.post("/reset", response_model=ResetResponse)
+@router.post(
+    "/reset",
+    response_model=ResetResponse,
+    summary="Reset simulation",
+    description="Initialize the ecosystem with a mix of organisms",
+)
 def reset_simulation(
     algae: int = Query(10),
     herbivores: int = Query(5),
@@ -52,14 +57,24 @@ def reset_simulation(
     return {"status": "reset", "organisms": len(engine.organisms)}
 
 
-@router.post("/step", response_model=StepResponse)
+@router.post(
+    "/step",
+    response_model=StepResponse,
+    summary="Advance simulation",
+    description="Advance the simulation by one discrete time step",
+)
 def step_simulation():
     """Advance the simulation by one step."""
     engine.step()
     return {"step": engine.step_count}
 
 
-@router.get("/state", response_model=StateResponse)
+@router.get(
+    "/state",
+    response_model=StateResponse,
+    summary="Get simulation state",
+    description="Return current step and organism details",
+)
 def state_simulation():
     """Return current simulation state."""
     organisms = [
@@ -74,7 +89,12 @@ def state_simulation():
     return {"step": engine.step_count, "organisms": organisms}
 
 
-@router.get("/stats", response_model=StatsResponse)
+@router.get(
+    "/stats",
+    response_model=StatsResponse,
+    summary="Get population stats",
+    description="Return counts for each organism type and current step",
+)
 def simulation_stats():
     """Return population counts and current step."""
     from collections import Counter

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,10 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from backend.api.simulation import router as simulation_router
 
-app = FastAPI(title="Ecosystem Simulation API")
+app = FastAPI(
+    title="Ecosystem Simulation API",
+    description="API for controlling and inspecting the ecosystem simulation",
+)
 
 origins = os.getenv("ALLOW_ORIGINS", "*").split(",")
 
@@ -19,7 +22,7 @@ app.add_middleware(
 app.include_router(simulation_router, prefix="/simulation")
 
 
-@app.get("/")
+@app.get("/", summary="Health check")
 def read_root():
     """Health check endpoint."""
     return {"status": "ok"}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,6 +1,6 @@
 export default [
   {
-    files: ['**/*.js', '**/*.jsx'],
+    files: ['**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx'],
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'module',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,13 +12,17 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.3"
+    "react-router-dom": "^6.22.3",
+    "konva": "^9.3.3"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.34.1",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "typescript": "^5.4.0",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.4.4",
     "vite": "^4.5.0"

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- commit to API docs and frontend setup tasks
- document endpoints with summaries for OpenAPI
- configure TypeScript React build with Vite
- record changes in CHANGELOG

## Testing
- `npm --prefix frontend run lint`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_683ebf8ade608331b856f572d5b51075