### PR TITLE
Add frontend tests with Vitest

### DIFF
--- a/.project-management/tasks/current-tasks.md
+++ b/.project-management/tasks/current-tasks.md
@@ -53,6 +53,11 @@
 - `frontend/src/api.ts` - API service helper functions
 - `frontend/src/components/ErrorBoundary.tsx` - React error boundary component
 - `frontend/src/index.css` - Global styles and CSS variables
+- `frontend/vitest.config.ts` - Vitest test configuration
+- `frontend/src/__tests__/App.test.tsx` - Unit test for main App component
+- `frontend/src/__tests__/ControlPanel.test.tsx` - Unit test for ControlPanel
+- `frontend/src/__tests__/StatsDisplay.test.tsx` - Unit test for StatsDisplay
+- `frontend/src/__tests__/SimulationCanvas.test.tsx` - Unit test for SimulationCanvas
 
 ### Notes
 
@@ -109,7 +114,7 @@
   - [x] 4.8 Set up React state management for simulation data and UI state
   - [x] 4.9 Add basic routing and error boundary components if needed
 
-- [ ] 5.0 Implement Organism Visualization and User Controls
+- [x] 5.0 Implement Organism Visualization and User Controls
   - [x] 5.1 Create SimulationCanvas component using HTML5 Canvas or React SVG
   - [x] 5.2 Implement organism rendering with color coding (green=algae, brown=herbivores, red=carnivores)
   - [x] 5.3 Add size-based visual representation for organisms (larger circles for bigger organisms)
@@ -119,4 +124,4 @@
   - [x] 5.7 Add real-time canvas updates when simulation state changes
   - [x] 5.8 Implement proper coordinate scaling between backend (500x500) and canvas display
   - [x] 5.9 Add basic error handling and loading states for user feedback
-  - [ ] 5.10 Write unit tests for all React components and user interactions
+  - [x] 5.10 Write unit tests for all React components and user interactions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 2025-06-03 Added OpenAPI summaries and TypeScript frontend setup
 2025-06-03 Added basic React app structure and API utilities
 2025-06-03 Added React state management, routing and canvas rendering
+2025-06-03 Added React component tests using Vitest

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -25,6 +26,11 @@
     "typescript": "^5.4.0",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.4.4",
-    "vite": "^4.5.0"
+    "vite": "^4.5.0",
+    "vitest": "^1.3.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.1.0",
+    "@testing-library/user-event": "^14.4.3",
+    "jsdom": "^22.1.0"
   }
 }

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as api from '../api';
+import App from '../App';
+
+vi.mock('../api');
+
+test('loads state on mount and handles step click', async () => {
+  (api.fetchState as any).mockResolvedValue({ step: 0, organisms: [] });
+  (api.fetchStats as any).mockResolvedValue({ step: 0, counts: {} });
+  (api.stepSimulation as any).mockResolvedValue(1);
+  render(<App />);
+  await screen.findByText(/Ecosystem Simulation/);
+  await userEvent.click(screen.getByText('Step'));
+  expect(api.stepSimulation).toHaveBeenCalled();
+});

--- a/frontend/src/__tests__/ControlPanel.test.tsx
+++ b/frontend/src/__tests__/ControlPanel.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ControlPanel from '../components/ControlPanel';
+
+test('calls handlers when buttons clicked', async () => {
+  const onReset = vi.fn();
+  const onStep = vi.fn();
+  render(<ControlPanel onReset={onReset} onStep={onStep} />);
+
+  await userEvent.click(screen.getByText(/Reset/i));
+  expect(onReset).toHaveBeenCalled();
+
+  await userEvent.click(screen.getByText(/Step/i));
+  expect(onStep).toHaveBeenCalled();
+});

--- a/frontend/src/__tests__/SimulationCanvas.test.tsx
+++ b/frontend/src/__tests__/SimulationCanvas.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import SimulationCanvas from '../components/SimulationCanvas';
+import { SimulationState } from '../types';
+
+test('renders canvas element', () => {
+  const state: SimulationState = { step: 0, organisms: [] };
+  const { container } = render(<SimulationCanvas state={state} />);
+  const canvas = container.querySelector('canvas');
+  expect(canvas).toBeInTheDocument();
+  expect(canvas?.getAttribute('width')).toBe('500');
+});

--- a/frontend/src/__tests__/StatsDisplay.test.tsx
+++ b/frontend/src/__tests__/StatsDisplay.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import * as api from '../api';
+import StatsDisplay from '../components/StatsDisplay';
+
+vi.mock('../api');
+
+test('loads and displays stats', async () => {
+  (api.fetchStats as any).mockResolvedValue({ step: 1, counts: { algae: 2 } });
+
+  render(<StatsDisplay />);
+  await waitFor(() => screen.getByText(/algae/i));
+
+  expect(screen.getByText('Step: 1')).toBeInTheDocument();
+  expect(screen.getByText(/algae: 2/)).toBeInTheDocument();
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["vitest/globals", "vite/client"]
   },
   "include": ["src"]
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- implement React component tests using Vitest
- configure Vitest and testing dependencies
- mark organism visualization tasks complete
- document tests in task tracker

## Testing
- `./run_tests.sh`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683ec4d1f3448331b3054b8edd472479