### PR TITLE
Add tasks for flashcard app

### DIFF
--- a/.project-management/tasks/current-tasks.md
+++ b/.project-management/tasks/current-tasks.md
@@ -1,0 +1,61 @@
+## Pre-Feature Development Project Tree
+```
+.
+frontend
+  eslint.config.js
+  package.json
+  package-lock.json
+run_tests.sh
+README.md
+dev_init.sh
+AGENTS.md
+CHANGELOG.md
+DEVELOPMENT.md
+backend
+  requirements.txt
+```
+
+## Relevant Files
+- `.project-management/prd-background/design-mockup.html` - Layout reference for UI components.
+- `.project-management/prd-background/environment-setup-postgres.md` - Guidance on local PostgreSQL setup.
+- `.project-management/prd-background/feature-request.md` - Details deck, card, and study functionality.
+
+### Proposed New Files
+- `backend/main.py` - FastAPI application entry point and API routing.
+- `backend/models.py` - SQLAlchemy models for users, decks, and cards.
+- `backend/auth.py` - User registration and login logic with session cookies.
+- `backend/database.py` - Database connection utilities.
+- `frontend/src/App.tsx` - React entry with routing configuration.
+- `frontend/src/pages/Login.tsx` - Login and registration page.
+- `frontend/src/pages/DeckList.tsx` - Deck management interface.
+- `frontend/src/pages/Study.tsx` - Study mode interface.
+
+### Existing Files Modified
+- `dev_init.sh` - Update to install dependencies and start backend/frontend for local dev.
+- `frontend/package.json` - Add scripts and dependencies for React project.
+- `backend/requirements.txt` - Include FastAPI, SQLAlchemy, and async PG driver.
+
+### Notes
+- Unit tests should typically be placed alongside the code files they are testing (e.g., `Login.tsx` and `Login.test.tsx`).
+- Use `npx jest [optional/path/to/test/file]` to run tests. Running without a path executes all tests found by the Jest configuration.
+
+## Tasks
+- [ ] 1.0 Initialize FastAPI backend with PostgreSQL
+  - [ ] 1.1 Create `backend/main.py` and configure FastAPI instance
+  - [ ] 1.2 Add `backend/database.py` for SQLAlchemy connection to Postgres
+  - [ ] 1.3 Define `User`, `Deck`, and `Card` models in `backend/models.py`
+  - [ ] 1.4 Set up migration or table creation logic
+- [ ] 2.0 Implement user authentication
+  - [ ] 2.1 Build registration and login endpoints in `backend/auth.py`
+  - [ ] 2.2 Store password hashes and manage session cookies
+  - [ ] 2.3 Create frontend `Login.tsx` for user signup/login
+- [ ] 3.0 Deck management features
+  - [ ] 3.1 API endpoints for creating, reading, updating, and deleting decks
+  - [ ] 3.2 Frontend `DeckList.tsx` page for deck CRUD operations
+- [ ] 4.0 Card management features
+  - [ ] 4.1 API endpoints for adding, editing, and deleting cards in a deck
+  - [ ] 4.2 UI components for card forms within `DeckList.tsx`
+- [ ] 5.0 Study mode implementation
+  - [ ] 5.1 Frontend `Study.tsx` to display one card at a time
+  - [ ] 5.2 Include card flip navigation and progress indicator
+  - [ ] 5.3 Ensure only the logged-in user's decks are accessible

--- a/.project-management/tasks/tasks-prd-flashcard-app.md
+++ b/.project-management/tasks/tasks-prd-flashcard-app.md
@@ -1,0 +1,61 @@
+## Pre-Feature Development Project Tree
+```
+.
+frontend
+  eslint.config.js
+  package.json
+  package-lock.json
+run_tests.sh
+README.md
+dev_init.sh
+AGENTS.md
+CHANGELOG.md
+DEVELOPMENT.md
+backend
+  requirements.txt
+```
+
+## Relevant Files
+- `.project-management/prd-background/design-mockup.html` - Layout reference for UI components.
+- `.project-management/prd-background/environment-setup-postgres.md` - Guidance on local PostgreSQL setup.
+- `.project-management/prd-background/feature-request.md` - Details deck, card, and study functionality.
+
+### Proposed New Files
+- `backend/main.py` - FastAPI application entry point and API routing.
+- `backend/models.py` - SQLAlchemy models for users, decks, and cards.
+- `backend/auth.py` - User registration and login logic with session cookies.
+- `backend/database.py` - Database connection utilities.
+- `frontend/src/App.tsx` - React entry with routing configuration.
+- `frontend/src/pages/Login.tsx` - Login and registration page.
+- `frontend/src/pages/DeckList.tsx` - Deck management interface.
+- `frontend/src/pages/Study.tsx` - Study mode interface.
+
+### Existing Files Modified
+- `dev_init.sh` - Update to install dependencies and start backend/frontend for local dev.
+- `frontend/package.json` - Add scripts and dependencies for React project.
+- `backend/requirements.txt` - Include FastAPI, SQLAlchemy, and async PG driver.
+
+### Notes
+- Unit tests should typically be placed alongside the code files they are testing (e.g., `Login.tsx` and `Login.test.tsx`).
+- Use `npx jest [optional/path/to/test/file]` to run tests. Running without a path executes all tests found by the Jest configuration.
+
+## Tasks
+- [ ] 1.0 Initialize FastAPI backend with PostgreSQL
+  - [ ] 1.1 Create `backend/main.py` and configure FastAPI instance
+  - [ ] 1.2 Add `backend/database.py` for SQLAlchemy connection to Postgres
+  - [ ] 1.3 Define `User`, `Deck`, and `Card` models in `backend/models.py`
+  - [ ] 1.4 Set up migration or table creation logic
+- [ ] 2.0 Implement user authentication
+  - [ ] 2.1 Build registration and login endpoints in `backend/auth.py`
+  - [ ] 2.2 Store password hashes and manage session cookies
+  - [ ] 2.3 Create frontend `Login.tsx` for user signup/login
+- [ ] 3.0 Deck management features
+  - [ ] 3.1 API endpoints for creating, reading, updating, and deleting decks
+  - [ ] 3.2 Frontend `DeckList.tsx` page for deck CRUD operations
+- [ ] 4.0 Card management features
+  - [ ] 4.1 API endpoints for adding, editing, and deleting cards in a deck
+  - [ ] 4.2 UI components for card forms within `DeckList.tsx`
+- [ ] 5.0 Study mode implementation
+  - [ ] 5.1 Frontend `Study.tsx` to display one card at a time
+  - [ ] 5.2 Include card flip navigation and progress indicator
+  - [ ] 5.3 Ensure only the logged-in user's decks are accessible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,4 @@
 2025-06-03T10:46:02Z - Added PRD for flashcard app
+2025-06-03T10:49:34Z - Added task list for flashcard app
+  - npm lint failed: No files matching the pattern 'src'
+  - Tests failed: backend/tests directory not found


### PR DESCRIPTION
## Summary
- generate tasks list from PRD
- copy tasks to `current-tasks.md`
- record changelog

## Testing
- `flake8`
- `npm run lint` *(fails: No files matching the pattern "src")*
- `./run_tests.sh` *(fails: backend/tests directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ed2c556488331b134371b4fcd747f