### PR TITLE
Implement login UI and deck API

### DIFF
--- a/.project-management/tasks/current-tasks.md
+++ b/.project-management/tasks/current-tasks.md
@@ -25,10 +25,10 @@ backend
 - `backend/models.py` - SQLAlchemy models for users, decks, and cards.
 - `backend/auth.py` - User registration and login logic with session cookies.
 - `backend/database.py` - Database connection utilities.
-- `frontend/src/App.tsx` - React entry with routing configuration.
-- `frontend/src/pages/Login.tsx` - Login and registration page.
-- `frontend/src/pages/DeckList.tsx` - Deck management interface.
-- `frontend/src/pages/Study.tsx` - Study mode interface.
+- `frontend/src/App.jsx` - React entry with routing configuration.
+- `frontend/src/pages/Login.jsx` - Login and registration page.
+- `frontend/src/pages/DeckList.jsx` - Deck management interface.
+- `frontend/src/pages/Study.jsx` - Study mode interface.
 
 ### New and Updated Files
 - `backend/main.py` - FastAPI app with startup table creation and health endpoint.
@@ -39,11 +39,18 @@ backend
 - `backend/requirements.txt` - Added SQLAlchemy and asyncpg dependencies.
 - `backend/auth.py` - User registration and login logic with in-memory sessions.
 - `backend/tests/test_auth.py` - Tests for registration and login endpoints.
+- `backend/decks.py` - CRUD endpoints for decks using in-memory store.
+- `backend/tests/test_decks.py` - Tests for deck API operations.
+- `frontend/index.html` - HTML entry point for Vite app.
+- `frontend/src/main.jsx` - React DOM rendering and router setup.
+- `frontend/src/App.jsx` - Application routes and navigation.
+- `frontend/src/pages/Login.jsx` - Login and registration form.
 
 ### Existing Files Modified
 - `dev_init.sh` - Update to install dependencies and start backend/frontend for local dev.
 - `frontend/package.json` - Add scripts and dependencies for React project.
 - `backend/requirements.txt` - Include FastAPI, SQLAlchemy, and async PG driver.
+- `frontend/eslint.config.js` - Enable linting for JS and JSX files.
 
 ### Notes
 - Unit tests should typically be placed alongside the code files they are testing (e.g., `Login.tsx` and `Login.test.tsx`).
@@ -55,12 +62,12 @@ backend
   - [x] 1.2 Add `backend/database.py` for SQLAlchemy connection to Postgres
   - [x] 1.3 Define `User`, `Deck`, and `Card` models in `backend/models.py`
   - [x] 1.4 Set up migration or table creation logic
-- [ ] 2.0 Implement user authentication
+- [x] 2.0 Implement user authentication
   - [x] 2.1 Build registration and login endpoints in `backend/auth.py`
   - [x] 2.2 Store password hashes and manage session cookies
-  - [ ] 2.3 Create frontend `Login.tsx` for user signup/login
+  - [x] 2.3 Create frontend `Login.tsx` for user signup/login
 - [ ] 3.0 Deck management features
-  - [ ] 3.1 API endpoints for creating, reading, updating, and deleting decks
+  - [x] 3.1 API endpoints for creating, reading, updating, and deleting decks
   - [ ] 3.2 Frontend `DeckList.tsx` page for deck CRUD operations
 - [ ] 4.0 Card management features
   - [ ] 4.1 API endpoints for adding, editing, and deleting cards in a deck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 2025-06-03T10:52:59Z - Implemented FastAPI backend skeleton with database models
 2025-06-03T10:59:37Z - Added basic auth endpoints and tests
   - npm lint failed: No files matching the pattern 'src'
+2025-06-03T11:06:30Z - Added login page, deck API router, and tests

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,6 +6,17 @@ This section describes development environment setup and is maintained by the co
 
 ### Frontend
 
+1. Install dependencies (from project root):
+   ```bash
+   cd frontend
+   npm install
+   ```
+
+2. Start the Vite development server:
+   ```bash
+   npm run dev
+   ```
+   The app is served at http://localhost:5173 by default.
 
 ### Backend
 

--- a/backend/decks.py
+++ b/backend/decks.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/decks")
+
+# In-memory store
+_decks = {}
+_next_id = 1
+
+
+class DeckIn(BaseModel):
+    name: str
+
+
+class DeckOut(DeckIn):
+    id: int
+
+
+@router.post("/", response_model=DeckOut)
+async def create_deck(deck: DeckIn):
+    global _next_id
+    deck_id = _next_id
+    _next_id += 1
+    _decks[deck_id] = deck.dict()
+    return {"id": deck_id, **deck.dict()}
+
+
+@router.get("/", response_model=list[DeckOut])
+async def list_decks():
+    return [{"id": i, **d} for i, d in _decks.items()]
+
+
+@router.put("/{deck_id}", response_model=DeckOut)
+async def update_deck(deck_id: int, deck: DeckIn):
+    if deck_id not in _decks:
+        raise HTTPException(status_code=404, detail="Deck not found")
+    _decks[deck_id] = deck.dict()
+    return {"id": deck_id, **deck.dict()}
+
+
+@router.delete("/{deck_id}")
+async def delete_deck(deck_id: int):
+    if deck_id not in _decks:
+        raise HTTPException(status_code=404, detail="Deck not found")
+    del _decks[deck_id]
+    return {"status": "deleted"}

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,9 +4,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .database import engine, get_db
 from .models import Base
 from .auth import router as auth_router
+from .decks import router as deck_router
 
 app = FastAPI()
 app.include_router(auth_router)
+app.include_router(deck_router)
 
 
 @app.on_event("startup")

--- a/backend/tests/test_decks.py
+++ b/backend/tests/test_decks.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+from backend.main import app
+
+client = TestClient(app)
+
+
+def test_deck_crud():
+    # create deck
+    resp = client.post('/decks/', json={'name': 'My Deck'})
+    assert resp.status_code == 200
+    data = resp.json()
+    deck_id = data['id']
+    assert data['name'] == 'My Deck'
+
+    # list decks
+    resp = client.get('/decks/')
+    assert resp.status_code == 200
+    assert any(d['id'] == deck_id for d in resp.json())
+
+    # update deck
+    resp = client.put(f'/decks/{deck_id}', json={'name': 'Updated'})
+    assert resp.status_code == 200
+    assert resp.json()['name'] == 'Updated'
+
+    # delete deck
+    resp = client.delete(f'/decks/{deck_id}')
+    assert resp.status_code == 200
+    assert resp.json() == {'status': 'deleted'}

--- a/dev_init.sh
+++ b/dev_init.sh
@@ -32,9 +32,12 @@ pip install -r backend/requirements.txt
 uvicorn backend.main:app --reload &
 
 # Start frontend in background
+npm --prefix frontend install >/dev/null
+npm --prefix frontend run dev &
 
 # Wait briefly for servers to start
+sleep 2
 
 # Open in default browser (macOS or Linux)
 
-#  Wait for servers to shut down manually
+# Wait for servers to shut down manually

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,6 +1,6 @@
 export default [
   {
-    files: ['**/*.js', '**/*.jsx'],
+    files: ['**/*.{js,jsx,ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'module',
@@ -10,4 +10,4 @@ export default [
     },
     rules: {},
   },
-]
+];

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Flashcard App</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Routes, Route, Link } from 'react-router-dom';
+import Login from './pages/Login';
+
+const App = () => (
+  <div className="min-h-screen p-4">
+    <nav className="mb-4">
+      <Link to="/login" className="mr-4">Login</Link>
+      <Link to="/decks">Decks</Link>
+    </nav>
+    <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route path="/" element={<Login />} />
+    </Routes>
+  </div>
+);
+
+export default App;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>,
+);

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+
+const Login = () => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleAction = async (endpoint) => {
+    try {
+      const resp = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+      if (!resp.ok) {
+        const data = await resp.json();
+        throw new Error(data.detail || 'error');
+      }
+      setMessage(endpoint.includes('login') ? 'Logged in!' : 'Registered!');
+    } catch (err) {
+      setMessage(err.message);
+    }
+  };
+
+  return (
+    <div className="max-w-sm mx-auto">
+      <h1 className="text-xl font-bold mb-4">Login or Register</h1>
+      <input
+        className="border p-2 mb-2 w-full"
+        placeholder="Username"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+      />
+      <input
+        className="border p-2 mb-2 w-full"
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <div className="flex gap-2 mb-2">
+        <button className="px-3 py-1 bg-blue-500 text-white" onClick={() => handleAction('/register')}>
+          Register
+        </button>
+        <button className="px-3 py-1 bg-green-500 text-white" onClick={() => handleAction('/login')}>
+          Login
+        </button>
+      </div>
+      {message && <p>{message}</p>}
+    </div>
+  );
+};
+
+export default Login;


### PR DESCRIPTION
## Summary
- create Login page and route with React Router
- wire up React entry points
- add deck CRUD endpoints and tests
- document frontend setup
- improve dev_init.sh with npm install
- update task list

## Testing
- `npm run lint`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_683ed66055208331bc2508ecee531c65