### PR TITLE
Implement deck list UI and card API

### DIFF
--- a/.project-management/tasks/current-tasks.md
+++ b/.project-management/tasks/current-tasks.md
@@ -41,10 +41,13 @@ backend
 - `backend/tests/test_auth.py` - Tests for registration and login endpoints.
 - `backend/decks.py` - CRUD endpoints for decks using in-memory store.
 - `backend/tests/test_decks.py` - Tests for deck API operations.
+- `backend/cards.py` - CRUD endpoints for cards using in-memory store.
+- `backend/tests/test_cards.py` - Tests for card API operations.
 - `frontend/index.html` - HTML entry point for Vite app.
 - `frontend/src/main.jsx` - React DOM rendering and router setup.
 - `frontend/src/App.jsx` - Application routes and navigation.
 - `frontend/src/pages/Login.jsx` - Login and registration form.
+- `frontend/src/pages/DeckList.jsx` - Deck management page.
 
 ### Existing Files Modified
 - `dev_init.sh` - Update to install dependencies and start backend/frontend for local dev.
@@ -66,11 +69,11 @@ backend
   - [x] 2.1 Build registration and login endpoints in `backend/auth.py`
   - [x] 2.2 Store password hashes and manage session cookies
   - [x] 2.3 Create frontend `Login.tsx` for user signup/login
-- [ ] 3.0 Deck management features
+- [x] 3.0 Deck management features
   - [x] 3.1 API endpoints for creating, reading, updating, and deleting decks
-  - [ ] 3.2 Frontend `DeckList.tsx` page for deck CRUD operations
+  - [x] 3.2 Frontend `DeckList.tsx` page for deck CRUD operations
 - [ ] 4.0 Card management features
-  - [ ] 4.1 API endpoints for adding, editing, and deleting cards in a deck
+  - [x] 4.1 API endpoints for adding, editing, and deleting cards in a deck
   - [ ] 4.2 UI components for card forms within `DeckList.tsx`
 - [ ] 5.0 Study mode implementation
   - [ ] 5.1 Frontend `Study.tsx` to display one card at a time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 2025-06-03T10:59:37Z - Added basic auth endpoints and tests
   - npm lint failed: No files matching the pattern 'src'
 2025-06-03T11:06:30Z - Added login page, deck API router, and tests
+2025-06-03T11:12:03Z - Added deck list UI and card API with tests

--- a/backend/cards.py
+++ b/backend/cards.py
@@ -1,0 +1,51 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/decks/{deck_id}/cards")
+
+# in-memory store: {deck_id: {card_id: {front, back}}}
+_cards = {}
+_next_id = 1
+
+
+class CardIn(BaseModel):
+    front: str
+    back: str
+
+
+class CardOut(CardIn):
+    id: int
+
+
+@router.post('/', response_model=CardOut)
+async def create_card(deck_id: int, card: CardIn):
+    global _next_id
+    deck_cards = _cards.setdefault(deck_id, {})
+    card_id = _next_id
+    _next_id += 1
+    deck_cards[card_id] = card.dict()
+    return {"id": card_id, **card.dict()}
+
+
+@router.get('/', response_model=list[CardOut])
+async def list_cards(deck_id: int):
+    deck_cards = _cards.get(deck_id, {})
+    return [{"id": cid, **data} for cid, data in deck_cards.items()]
+
+
+@router.put('/{card_id}', response_model=CardOut)
+async def update_card(deck_id: int, card_id: int, card: CardIn):
+    deck_cards = _cards.get(deck_id, {})
+    if card_id not in deck_cards:
+        raise HTTPException(status_code=404, detail="Card not found")
+    deck_cards[card_id] = card.dict()
+    return {"id": card_id, **card.dict()}
+
+
+@router.delete('/{card_id}')
+async def delete_card(deck_id: int, card_id: int):
+    deck_cards = _cards.get(deck_id, {})
+    if card_id not in deck_cards:
+        raise HTTPException(status_code=404, detail="Card not found")
+    del deck_cards[card_id]
+    return {"status": "deleted"}

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,10 +5,12 @@ from .database import engine, get_db
 from .models import Base
 from .auth import router as auth_router
 from .decks import router as deck_router
+from .cards import router as card_router
 
 app = FastAPI()
 app.include_router(auth_router)
 app.include_router(deck_router)
+app.include_router(card_router)
 
 
 @app.on_event("startup")

--- a/backend/tests/test_cards.py
+++ b/backend/tests/test_cards.py
@@ -1,0 +1,35 @@
+from fastapi.testclient import TestClient
+from backend.main import app
+
+client = TestClient(app)
+
+
+def test_card_crud():
+    # create deck first
+    resp = client.post('/decks/', json={'name': 'Deck1'})
+    deck_id = resp.json()['id']
+
+    # create card
+    resp = client.post(f'/decks/{deck_id}/cards/', json={'front': 'a', 'back': 'b'})
+    assert resp.status_code == 200
+    card = resp.json()
+    card_id = card['id']
+    assert card['front'] == 'a'
+
+    # list cards
+    resp = client.get(f'/decks/{deck_id}/cards/')
+    assert resp.status_code == 200
+    assert any(c['id'] == card_id for c in resp.json())
+
+    # update card
+    resp = client.put(
+        f'/decks/{deck_id}/cards/{card_id}',
+        json={'front': 'c', 'back': 'd'}
+    )
+    assert resp.status_code == 200
+    assert resp.json()['front'] == 'c'
+
+    # delete card
+    resp = client.delete(f'/decks/{deck_id}/cards/{card_id}')
+    assert resp.status_code == 200
+    assert resp.json() == {'status': 'deleted'}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Routes, Route, Link } from 'react-router-dom';
 import Login from './pages/Login';
+import DeckList from './pages/DeckList';
 
 const App = () => (
   <div className="min-h-screen p-4">
@@ -10,6 +11,7 @@ const App = () => (
     </nav>
     <Routes>
       <Route path="/login" element={<Login />} />
+      <Route path="/decks" element={<DeckList />} />
       <Route path="/" element={<Login />} />
     </Routes>
   </div>

--- a/frontend/src/pages/DeckList.jsx
+++ b/frontend/src/pages/DeckList.jsx
@@ -1,0 +1,94 @@
+import React, { useState, useEffect } from 'react';
+
+const DeckList = () => {
+  const [decks, setDecks] = useState([]);
+  const [newName, setNewName] = useState('');
+  const [editNames, setEditNames] = useState({});
+
+  const fetchDecks = async () => {
+    const resp = await fetch('/decks/');
+    if (resp.ok) {
+      setDecks(await resp.json());
+    }
+  };
+
+  useEffect(() => {
+    fetchDecks();
+  }, []);
+
+  const createDeck = async () => {
+    const resp = await fetch('/decks/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: newName }),
+    });
+    if (resp.ok) {
+      setNewName('');
+      fetchDecks();
+    }
+  };
+
+  const updateDeck = async (id) => {
+    const name = editNames[id] || '';
+    const resp = await fetch(`/decks/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    if (resp.ok) {
+      setEditNames((e) => ({ ...e, [id]: '' }));
+      fetchDecks();
+    }
+  };
+
+  const deleteDeck = async (id) => {
+    const resp = await fetch(`/decks/${id}`, { method: 'DELETE' });
+    if (resp.ok) {
+      fetchDecks();
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto">
+      <h1 className="text-xl font-bold mb-2">Decks</h1>
+      <div className="flex mb-4 gap-2">
+        <input
+          className="border p-1 flex-1"
+          placeholder="New deck name"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white px-2" onClick={createDeck}>
+          Add
+        </button>
+      </div>
+      <ul>
+        {decks.map((d) => (
+          <li key={d.id} className="mb-2 border p-2 flex items-center gap-2">
+            <input
+              className="border p-1 flex-1"
+              value={editNames[d.id] ?? d.name}
+              onChange={(e) =>
+                setEditNames((cur) => ({ ...cur, [d.id]: e.target.value }))
+              }
+            />
+            <button
+              className="bg-green-500 text-white px-2"
+              onClick={() => updateDeck(d.id)}
+            >
+              Save
+            </button>
+            <button
+              className="bg-red-500 text-white px-2"
+              onClick={() => deleteDeck(d.id)}
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default DeckList;


### PR DESCRIPTION
## Summary
- create frontend DeckList page for CRUD UI
- route deck list page in App.jsx
- add card API endpoints and integrate with FastAPI
- test card API behavior
- update tasks and changelog

## Testing
- `npm --prefix frontend run lint`
- `flake8`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_683ed7d8302c8331b7c28abee7626a8f