### PR TITLE
Implement card management UI

### DIFF
--- a/.project-management/tasks/current-tasks.md
+++ b/.project-management/tasks/current-tasks.md
@@ -72,9 +72,9 @@ backend
 - [x] 3.0 Deck management features
   - [x] 3.1 API endpoints for creating, reading, updating, and deleting decks
   - [x] 3.2 Frontend `DeckList.tsx` page for deck CRUD operations
-- [ ] 4.0 Card management features
+- [x] 4.0 Card management features
   - [x] 4.1 API endpoints for adding, editing, and deleting cards in a deck
-  - [ ] 4.2 UI components for card forms within `DeckList.tsx`
+  - [x] 4.2 UI components for card forms within `DeckList.tsx`
 - [ ] 5.0 Study mode implementation
   - [ ] 5.1 Frontend `Study.tsx` to display one card at a time
   - [ ] 5.2 Include card flip navigation and progress indicator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
   - npm lint failed: No files matching the pattern 'src'
 2025-06-03T11:06:30Z - Added login page, deck API router, and tests
 2025-06-03T11:12:03Z - Added deck list UI and card API with tests
+2025-06-03T11:15:54Z - Added card management UI in DeckList

--- a/frontend/src/pages/DeckList.jsx
+++ b/frontend/src/pages/DeckList.jsx
@@ -4,6 +4,10 @@ const DeckList = () => {
   const [decks, setDecks] = useState([]);
   const [newName, setNewName] = useState('');
   const [editNames, setEditNames] = useState({});
+  const [showCards, setShowCards] = useState({});
+  const [cards, setCards] = useState({});
+  const [newCards, setNewCards] = useState({});
+  const [editCards, setEditCards] = useState({});
 
   const fetchDecks = async () => {
     const resp = await fetch('/decks/');
@@ -48,6 +52,53 @@ const DeckList = () => {
     }
   };
 
+  const fetchCards = async (deckId) => {
+    const resp = await fetch(`/decks/${deckId}/cards/`);
+    if (resp.ok) {
+      const list = await resp.json();
+      setCards((c) => ({ ...c, [deckId]: list }));
+    }
+  };
+
+  const createCard = async (deckId) => {
+    const card = newCards[deckId] || { front: '', back: '' };
+    const resp = await fetch(`/decks/${deckId}/cards/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(card),
+    });
+    if (resp.ok) {
+      setNewCards((n) => ({ ...n, [deckId]: { front: '', back: '' } }));
+      fetchCards(deckId);
+    }
+  };
+
+  const updateCard = async (deckId, cardId) => {
+    const card = (editCards[deckId] && editCards[deckId][cardId]) || {
+      front: '',
+      back: '',
+    };
+    const resp = await fetch(`/decks/${deckId}/cards/${cardId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(card),
+    });
+    if (resp.ok) {
+      setEditCards((e) => ({
+        ...e,
+        [deckId]: { ...(e[deckId] || {}), [cardId]: { front: '', back: '' } },
+      }));
+      fetchCards(deckId);
+    }
+  };
+
+  const deleteCard = async (deckId, cardId) => {
+    const resp = await fetch(`/decks/${deckId}/cards/${cardId}`, { method: 'DELETE' });
+    if (resp.ok) {
+      fetchCards(deckId);
+    }
+  };
+
   return (
     <div className="max-w-md mx-auto">
       <h1 className="text-xl font-bold mb-2">Decks</h1>
@@ -64,26 +115,127 @@ const DeckList = () => {
       </div>
       <ul>
         {decks.map((d) => (
-          <li key={d.id} className="mb-2 border p-2 flex items-center gap-2">
-            <input
-              className="border p-1 flex-1"
-              value={editNames[d.id] ?? d.name}
-              onChange={(e) =>
-                setEditNames((cur) => ({ ...cur, [d.id]: e.target.value }))
-              }
-            />
-            <button
-              className="bg-green-500 text-white px-2"
-              onClick={() => updateDeck(d.id)}
-            >
-              Save
-            </button>
-            <button
-              className="bg-red-500 text-white px-2"
-              onClick={() => deleteDeck(d.id)}
-            >
-              Delete
-            </button>
+          <li key={d.id} className="mb-4 border p-2">
+            <div className="flex items-center gap-2 mb-2">
+              <input
+                className="border p-1 flex-1"
+                value={editNames[d.id] ?? d.name}
+                onChange={(e) =>
+                  setEditNames((cur) => ({ ...cur, [d.id]: e.target.value }))
+                }
+              />
+              <button
+                className="bg-green-500 text-white px-2"
+                onClick={() => updateDeck(d.id)}
+              >
+                Save
+              </button>
+              <button
+                className="bg-red-500 text-white px-2"
+                onClick={() => deleteDeck(d.id)}
+              >
+                Delete
+              </button>
+              <button
+                className="bg-gray-500 text-white px-2"
+                onClick={() => {
+                  setShowCards((s) => ({ ...s, [d.id]: !s[d.id] }));
+                  if (!showCards[d.id]) fetchCards(d.id);
+                }}
+              >
+                {showCards[d.id] ? 'Hide Cards' : 'Cards'}
+              </button>
+            </div>
+            {showCards[d.id] && (
+              <div className="ml-4">
+                <div className="flex gap-2 mb-2">
+                  <input
+                    className="border p-1 flex-1"
+                    placeholder="Front"
+                    value={newCards[d.id]?.front || ''}
+                    onChange={(e) =>
+                      setNewCards((n) => ({
+                        ...n,
+                        [d.id]: { ...(n[d.id] || {}), front: e.target.value },
+                      }))
+                    }
+                  />
+                  <input
+                    className="border p-1 flex-1"
+                    placeholder="Back"
+                    value={newCards[d.id]?.back || ''}
+                    onChange={(e) =>
+                      setNewCards((n) => ({
+                        ...n,
+                        [d.id]: { ...(n[d.id] || {}), back: e.target.value },
+                      }))
+                    }
+                  />
+                  <button
+                    className="bg-blue-500 text-white px-2"
+                    onClick={() => createCard(d.id)}
+                  >
+                    Add Card
+                  </button>
+                </div>
+                <ul>
+                  {(cards[d.id] || []).map((c) => (
+                    <li key={c.id} className="mb-2 flex gap-2 items-center">
+                      <input
+                        className="border p-1 flex-1"
+                        value={
+                          (editCards[d.id] && editCards[d.id][c.id]?.front) ||
+                          c.front
+                        }
+                        onChange={(e) =>
+                          setEditCards((cur) => ({
+                            ...cur,
+                            [d.id]: {
+                              ...(cur[d.id] || {}),
+                              [c.id]: {
+                                ...(cur[d.id]?.[c.id] || c),
+                                front: e.target.value,
+                              },
+                            },
+                          }))
+                        }
+                      />
+                      <input
+                        className="border p-1 flex-1"
+                        value={
+                          (editCards[d.id] && editCards[d.id][c.id]?.back) ||
+                          c.back
+                        }
+                        onChange={(e) =>
+                          setEditCards((cur) => ({
+                            ...cur,
+                            [d.id]: {
+                              ...(cur[d.id] || {}),
+                              [c.id]: {
+                                ...(cur[d.id]?.[c.id] || c),
+                                back: e.target.value,
+                              },
+                            },
+                          }))
+                        }
+                      />
+                      <button
+                        className="bg-green-500 text-white px-2"
+                        onClick={() => updateCard(d.id, c.id)}
+                      >
+                        Save
+                      </button>
+                      <button
+                        className="bg-red-500 text-white px-2"
+                        onClick={() => deleteCard(d.id, c.id)}
+                      >
+                        Delete
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- implement card CRUD UI on DeckList page
- mark card management tasks complete
- document change in CHANGELOG

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_683ed8cf797c833195c4abe227ebfc4c