### PR TITLE
Implement study mode and user deck restrictions

### DIFF
--- a/.project-management/tasks/current-tasks.md
+++ b/.project-management/tasks/current-tasks.md
@@ -75,7 +75,7 @@ backend
 - [x] 4.0 Card management features
   - [x] 4.1 API endpoints for adding, editing, and deleting cards in a deck
   - [x] 4.2 UI components for card forms within `DeckList.tsx`
-- [ ] 5.0 Study mode implementation
-  - [ ] 5.1 Frontend `Study.tsx` to display one card at a time
-  - [ ] 5.2 Include card flip navigation and progress indicator
-  - [ ] 5.3 Ensure only the logged-in user's decks are accessible
+- [x] 5.0 Study mode implementation
+  - [x] 5.1 Frontend `Study.tsx` to display one card at a time
+  - [x] 5.2 Include card flip navigation and progress indicator
+  - [x] 5.3 Ensure only the logged-in user's decks are accessible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 2025-06-03T11:06:30Z - Added login page, deck API router, and tests
 2025-06-03T11:12:03Z - Added deck list UI and card API with tests
 2025-06-03T11:15:54Z - Added card management UI in DeckList
+2025-06-03T11:20:25Z - Added study mode UI and auth restrictions

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, HTTPException, Response, Request
 from pydantic import BaseModel
 import hashlib
 import secrets
@@ -36,3 +36,11 @@ async def login(creds: UserCredentials, response: Response):
     sessions[token] = creds.username
     response.set_cookie("session_token", token, httponly=True)
     return {"status": "logged_in"}
+
+
+def get_current_user(request: Request) -> str:
+    token = request.cookies.get("session_token")
+    user = sessions.get(token)
+    if not user:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    return user

--- a/backend/cards.py
+++ b/backend/cards.py
@@ -1,5 +1,7 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel
+from .auth import get_current_user
+from .decks import _decks
 
 router = APIRouter(prefix="/decks/{deck_id}/cards")
 
@@ -18,7 +20,13 @@ class CardOut(CardIn):
 
 
 @router.post('/', response_model=CardOut)
-async def create_card(deck_id: int, card: CardIn):
+async def create_card(
+    deck_id: int,
+    card: CardIn,
+    user: str = Depends(get_current_user),
+):
+    if deck_id not in _decks or _decks[deck_id]["owner"] != user:
+        raise HTTPException(status_code=404, detail="Deck not found")
     global _next_id
     deck_cards = _cards.setdefault(deck_id, {})
     card_id = _next_id
@@ -28,13 +36,22 @@ async def create_card(deck_id: int, card: CardIn):
 
 
 @router.get('/', response_model=list[CardOut])
-async def list_cards(deck_id: int):
+async def list_cards(deck_id: int, user: str = Depends(get_current_user)):
+    if deck_id not in _decks or _decks[deck_id]["owner"] != user:
+        raise HTTPException(status_code=404, detail="Deck not found")
     deck_cards = _cards.get(deck_id, {})
     return [{"id": cid, **data} for cid, data in deck_cards.items()]
 
 
 @router.put('/{card_id}', response_model=CardOut)
-async def update_card(deck_id: int, card_id: int, card: CardIn):
+async def update_card(
+    deck_id: int,
+    card_id: int,
+    card: CardIn,
+    user: str = Depends(get_current_user),
+):
+    if deck_id not in _decks or _decks[deck_id]["owner"] != user:
+        raise HTTPException(status_code=404, detail="Deck not found")
     deck_cards = _cards.get(deck_id, {})
     if card_id not in deck_cards:
         raise HTTPException(status_code=404, detail="Card not found")
@@ -43,7 +60,13 @@ async def update_card(deck_id: int, card_id: int, card: CardIn):
 
 
 @router.delete('/{card_id}')
-async def delete_card(deck_id: int, card_id: int):
+async def delete_card(
+    deck_id: int,
+    card_id: int,
+    user: str = Depends(get_current_user),
+):
+    if deck_id not in _decks or _decks[deck_id]["owner"] != user:
+        raise HTTPException(status_code=404, detail="Deck not found")
     deck_cards = _cards.get(deck_id, {})
     if card_id not in deck_cards:
         raise HTTPException(status_code=404, detail="Card not found")

--- a/backend/tests/test_cards.py
+++ b/backend/tests/test_cards.py
@@ -5,6 +5,8 @@ client = TestClient(app)
 
 
 def test_card_crud():
+    client.post("/register", json={"username": "carol", "password": "pw"})
+    client.post("/login", json={"username": "carol", "password": "pw"})
     # create deck first
     resp = client.post('/decks/', json={'name': 'Deck1'})
     deck_id = resp.json()['id']

--- a/backend/tests/test_decks.py
+++ b/backend/tests/test_decks.py
@@ -5,6 +5,8 @@ client = TestClient(app)
 
 
 def test_deck_crud():
+    client.post("/register", json={"username": "bob", "password": "pw"})
+    client.post("/login", json={"username": "bob", "password": "pw"})
     # create deck
     resp = client.post('/decks/', json={'name': 'My Deck'})
     assert resp.status_code == 200

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,6 @@
 </head>
 <body>
   <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
+  <script type="module" src="/src/main.jsx"></script>
 </body>
 </html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Routes, Route, Link } from 'react-router-dom';
 import Login from './pages/Login';
 import DeckList from './pages/DeckList';
+import Study from './pages/Study';
 
 const App = () => (
   <div className="min-h-screen p-4">
@@ -12,6 +13,7 @@ const App = () => (
     <Routes>
       <Route path="/login" element={<Login />} />
       <Route path="/decks" element={<DeckList />} />
+      <Route path="/study/:deckId" element={<Study />} />
       <Route path="/" element={<Login />} />
     </Routes>
   </div>

--- a/frontend/src/pages/DeckList.jsx
+++ b/frontend/src/pages/DeckList.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 
 const DeckList = () => {
   const [decks, setDecks] = useState([]);
@@ -136,6 +137,9 @@ const DeckList = () => {
               >
                 Delete
               </button>
+              <Link to={`/study/${d.id}`} className="bg-purple-500 text-white px-2">
+                Study
+              </Link>
               <button
                 className="bg-gray-500 text-white px-2"
                 onClick={() => {

--- a/frontend/src/pages/Study.jsx
+++ b/frontend/src/pages/Study.jsx
@@ -1,0 +1,62 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+
+const Study = () => {
+  const { deckId } = useParams();
+  const [cards, setCards] = useState([]);
+  const [index, setIndex] = useState(0);
+  const [flipped, setFlipped] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      const resp = await fetch(`/decks/${deckId}/cards/`);
+      if (resp.ok) {
+        setCards(await resp.json());
+      }
+    };
+    load();
+  }, [deckId]);
+
+  if (!cards.length) {
+    return <p className="text-center">No cards to study</p>;
+  }
+
+  const card = cards[index];
+  const next = () => {
+    setFlipped(false);
+    setIndex((i) => Math.min(i + 1, cards.length - 1));
+  };
+  const prev = () => {
+    setFlipped(false);
+    setIndex((i) => Math.max(i - 1, 0));
+  };
+
+  return (
+    <div className="max-w-md mx-auto text-center">
+      <h1 className="text-xl font-bold mb-2">Study</h1>
+      <p className="mb-2">Card {index + 1} of {cards.length}</p>
+      <div
+        className="border p-4 mb-4 cursor-pointer"
+        onClick={() => setFlipped((f) => !f)}
+      >
+        {flipped ? card.back : card.front}
+      </div>
+      <div className="flex justify-center gap-2">
+        <button onClick={prev} disabled={index === 0} className="px-2 border">
+          Prev
+        </button>
+        <button onClick={() => setFlipped((f) => !f)} className="px-2 border">
+          Flip
+        </button>
+        <button onClick={next} disabled={index === cards.length - 1} className="px-2 border">
+          Next
+        </button>
+      </div>
+      <Link to="/decks" className="block mt-4 underline">
+        Back to Decks
+      </Link>
+    </div>
+  );
+};
+
+export default Study;


### PR DESCRIPTION
## Summary
- add Study page and hook it into router
- link Study button from DeckList
- add get_current_user helper and require authentication for deck/card routes
- restrict decks and cards to logged in user
- create Study page with flip/next/prev controls
- update tests for auth requirements
- update index.html script reference
- update task list

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683ed9a76884833189b3756413f4fc2c