### PR TITLE
Implement design mockup styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 2025-06-03T11:12:03Z - Added deck list UI and card API with tests
 2025-06-03T11:15:54Z - Added card management UI in DeckList
 2025-06-03T11:20:25Z - Added study mode UI and auth restrictions
+2025-06-03T16:40:28Z - Applied design mockup styling and layout

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,18 +5,22 @@ import DeckList from './pages/DeckList';
 import Study from './pages/Study';
 
 const App = () => (
-  <div className="min-h-screen p-4">
-    <nav className="mb-4">
-      <Link to="/login" className="mr-4">Login</Link>
-      <Link to="/decks">Decks</Link>
-    </nav>
-    <Routes>
-      <Route path="/login" element={<Login />} />
-      <Route path="/decks" element={<DeckList />} />
-      <Route path="/study/:deckId" element={<Study />} />
-      <Route path="/" element={<Login />} />
-    </Routes>
-  </div>
+  <>
+    <header>
+      <h1>Flashcard Study App</h1>
+    </header>
+    <div className="container">
+      <nav>
+        <Link to="/decks">My Decks</Link>
+      </nav>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route path="/decks" element={<DeckList />} />
+        <Route path="/study/:deckId" element={<Study />} />
+        <Route path="/" element={<Login />} />
+      </Routes>
+    </div>
+  </>
 );
 
 export default App;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import './styles.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/frontend/src/pages/DeckList.jsx
+++ b/frontend/src/pages/DeckList.jsx
@@ -101,47 +101,34 @@ const DeckList = () => {
   };
 
   return (
-    <div className="max-w-md mx-auto">
-      <h1 className="text-xl font-bold mb-2">Decks</h1>
-      <div className="flex mb-4 gap-2">
+    <div>
+      <h2>My Decks</h2>
+      <div className="form-group">
         <input
-          className="border p-1 flex-1"
           placeholder="New deck name"
           value={newName}
           onChange={(e) => setNewName(e.target.value)}
+          type="text"
         />
-        <button className="bg-blue-500 text-white px-2" onClick={createDeck}>
-          Add
-        </button>
+        <button onClick={createDeck}>Add</button>
       </div>
-      <ul>
+      <ul className="deck-list">
         {decks.map((d) => (
-          <li key={d.id} className="mb-4 border p-2">
-            <div className="flex items-center gap-2 mb-2">
+          <li key={d.id}>
+            <div>
               <input
-                className="border p-1 flex-1"
                 value={editNames[d.id] ?? d.name}
                 onChange={(e) =>
                   setEditNames((cur) => ({ ...cur, [d.id]: e.target.value }))
                 }
+                type="text"
               />
+            </div>
+            <div className="deck-actions">
+              <button onClick={() => updateDeck(d.id)}>Save</button>
+              <button className="danger" onClick={() => deleteDeck(d.id)}>Delete</button>
+              <Link to={`/study/${d.id}`}>Study</Link>
               <button
-                className="bg-green-500 text-white px-2"
-                onClick={() => updateDeck(d.id)}
-              >
-                Save
-              </button>
-              <button
-                className="bg-red-500 text-white px-2"
-                onClick={() => deleteDeck(d.id)}
-              >
-                Delete
-              </button>
-              <Link to={`/study/${d.id}`} className="bg-purple-500 text-white px-2">
-                Study
-              </Link>
-              <button
-                className="bg-gray-500 text-white px-2"
                 onClick={() => {
                   setShowCards((s) => ({ ...s, [d.id]: !s[d.id] }));
                   if (!showCards[d.id]) fetchCards(d.id);
@@ -152,9 +139,8 @@ const DeckList = () => {
             </div>
             {showCards[d.id] && (
               <div className="ml-4">
-                <div className="flex gap-2 mb-2">
+                <div className="form-group">
                   <input
-                    className="border p-1 flex-1"
                     placeholder="Front"
                     value={newCards[d.id]?.front || ''}
                     onChange={(e) =>
@@ -163,9 +149,9 @@ const DeckList = () => {
                         [d.id]: { ...(n[d.id] || {}), front: e.target.value },
                       }))
                     }
+                    type="text"
                   />
                   <input
-                    className="border p-1 flex-1"
                     placeholder="Back"
                     value={newCards[d.id]?.back || ''}
                     onChange={(e) =>
@@ -174,19 +160,14 @@ const DeckList = () => {
                         [d.id]: { ...(n[d.id] || {}), back: e.target.value },
                       }))
                     }
+                    type="text"
                   />
-                  <button
-                    className="bg-blue-500 text-white px-2"
-                    onClick={() => createCard(d.id)}
-                  >
-                    Add Card
-                  </button>
+                  <button onClick={() => createCard(d.id)}>Add Card</button>
                 </div>
-                <ul>
+                <ul className="card-list">
                   {(cards[d.id] || []).map((c) => (
-                    <li key={c.id} className="mb-2 flex gap-2 items-center">
+                    <li key={c.id}>
                       <input
-                        className="border p-1 flex-1"
                         value={
                           (editCards[d.id] && editCards[d.id][c.id]?.front) ||
                           c.front
@@ -203,9 +184,9 @@ const DeckList = () => {
                             },
                           }))
                         }
+                        type="text"
                       />
                       <input
-                        className="border p-1 flex-1"
                         value={
                           (editCards[d.id] && editCards[d.id][c.id]?.back) ||
                           c.back
@@ -222,17 +203,10 @@ const DeckList = () => {
                             },
                           }))
                         }
+                        type="text"
                       />
-                      <button
-                        className="bg-green-500 text-white px-2"
-                        onClick={() => updateCard(d.id, c.id)}
-                      >
-                        Save
-                      </button>
-                      <button
-                        className="bg-red-500 text-white px-2"
-                        onClick={() => deleteCard(d.id, c.id)}
-                      >
+                      <button onClick={() => updateCard(d.id, c.id)}>Save</button>
+                      <button className="danger" onClick={() => deleteCard(d.id, c.id)}>
                         Delete
                       </button>
                     </li>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,130 @@
+:root {
+  --bg-color: #EFE4D2;
+  --primary-color: #131D4F;
+  --secondary-color: #254D70;
+  --accent-color: #954C2E;
+  --text-color-light: #EFE4D2;
+  --text-color-dark: #131D4F;
+  --border-color: #ccc;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  background-color: var(--bg-color);
+  color: var(--text-color-dark);
+  line-height: 1.6;
+}
+
+.container {
+  max-width: 900px;
+  margin: 20px auto;
+  padding: 20px;
+  background-color: white;
+  box-shadow: 0 0 10px rgba(0,0,0,0.1);
+  border-radius: 8px;
+}
+
+header {
+  background-color: var(--primary-color);
+  color: var(--text-color-light);
+  padding: 1rem;
+  text-align: center;
+  border-radius: 8px 8px 0 0;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 2em;
+}
+
+nav {
+  background-color: var(--secondary-color);
+  padding: 0.5rem;
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+nav a {
+  margin: 0 10px;
+  color: var(--text-color-light);
+  text-decoration: none;
+}
+
+button {
+  background-color: var(--secondary-color);
+  color: var(--text-color-light);
+  border: none;
+  padding: 10px 15px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 1em;
+  transition: background-color 0.3s ease;
+}
+
+button:hover {
+  background-color: var(--primary-color);
+}
+
+button.danger {
+  background-color: var(--accent-color);
+}
+
+button.danger:hover {
+  background-color: #7a3c23;
+}
+
+ul.deck-list, ul.card-list {
+  list-style: none;
+  padding: 0;
+}
+
+.deck-list li, .card-list li {
+  background-color: #fff;
+  border: 1px solid var(--border-color);
+  padding: 10px;
+  margin-bottom: 10px;
+  border-radius: 4px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.deck-actions button,
+.card-actions button {
+  margin-left: 5px;
+}
+
+.study-card {
+  background-color: #fff;
+  border: 2px solid var(--secondary-color);
+  padding: 30px;
+  min-height: 200px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  border-radius: 8px;
+  font-size: 1.5em;
+  cursor: pointer;
+  margin-bottom: 20px;
+}
+
+.study-card .card-side-label {
+  font-size: 0.7em;
+  color: var(--accent-color);
+  margin-bottom: 5px;
+}
+
+.study-navigation {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.study-progress {
+  font-style: italic;
+  color: var(--secondary-color);
+}


### PR DESCRIPTION
## Summary
- add global styles matching design-mockup
- use layout container and header
- update deck list markup to use design classes

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_683f24cb4e588331b7a6f916036c5e5e