### PR TITLE
Implement main game loop

### DIFF
--- a/.project-management/current-prd/tasks-prd-space-man-pac-invaders-mvp.md
+++ b/.project-management/current-prd/tasks-prd-space-man-pac-invaders-mvp.md
@@ -31,6 +31,12 @@ run_tests.sh
 - `frontend/vite.config.ts`
 - `frontend/src/index.css`
 - `frontend/src/App.tsx`
+- `frontend/src/main.tsx` - React/Vite bootstrap file.
+- `frontend/src/components/GameCanvas.tsx` - Canvas rendering component.
+- `frontend/src/components/GameHeader.tsx` - Displays title, score, lives.
+- `frontend/src/components/HighScoresPanel.tsx` - Shows leaderboard.
+- `frontend/src/components/GameFooter.tsx` - Handles messages and initials form.
+- `frontend/src/game/logic.ts` - Core gameplay loop and mechanics.
 
 ### Proposed New Files
 - `backend/app/main.py` - FastAPI application entrypoint.
@@ -72,7 +78,7 @@ run_tests.sh
   - [x] 2.3 Add `<canvas>` element wrapped by `GameCanvas` component.
   - [x] 2.4 Ensure layout matches the mockup styling.
 - [ ] 3.0 Core Gameplay Mechanics
-  - [ ] 3.1 Implement main game loop in `logic.ts` with `requestAnimationFrame`.
+  - [x] 3.1 Implement main game loop in `logic.ts` with `requestAnimationFrame`.
   - [ ] 3.2 Implement player movement, shooting, and collision detection.
   - [ ] 3.3 Implement invader movement, projectiles, and pellet collection.
   - [ ] 3.4 Track levels, lives, and scoring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 2025-06-03 Added PRD for Space Man Pac Invaders MVP
 2025-06-03 Added minimal FastAPI/React scaffolding and dev scripts
 2025-06-03 Added pixel font styling and completed layout tasks
+2025-06-03 Implemented basic requestAnimationFrame game loop

--- a/frontend/src/components/GameCanvas.tsx
+++ b/frontend/src/components/GameCanvas.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect } from 'react'
+import { startGame } from '../game/logic'
 
 const GameCanvas = () => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
@@ -8,8 +9,7 @@ const GameCanvas = () => {
     if (!canvas) return
     const ctx = canvas.getContext('2d')
     if (!ctx) return
-    ctx.fillStyle = 'black'
-    ctx.fillRect(0, 0, canvas.width, canvas.height)
+    startGame(ctx)
   }, [])
 
   return <canvas ref={canvasRef} width={480} height={320} className="bg-black border border-green-500" />

--- a/frontend/src/game/logic.ts
+++ b/frontend/src/game/logic.ts
@@ -1,7 +1,18 @@
-export function startGame() {
-  // Placeholder game loop
+export function startGame(ctx: CanvasRenderingContext2D) {
   const step = () => {
+    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height)
+
+    // Temporary player rectangle
+    ctx.fillStyle = 'green'
+    ctx.fillRect(
+      ctx.canvas.width / 2 - 10,
+      ctx.canvas.height - 20,
+      20,
+      10
+    )
+
     requestAnimationFrame(step)
   }
+
   step()
 }


### PR DESCRIPTION
## Summary
- add missing frontend file references to task list
- implement a basic `startGame` loop with requestAnimationFrame
- launch the loop from `GameCanvas`
- record changes in CHANGELOG
- mark 3.1 task complete

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_683f59082bf08331b876e85e656626db