### PR TITLE
Implement high score frontend integration

### DIFF
--- a/.project-management/current-prd/tasks-prd-space-man-pac-invaders-mvp.md
+++ b/.project-management/current-prd/tasks-prd-space-man-pac-invaders-mvp.md
@@ -32,6 +32,7 @@ run_tests.sh
 - `frontend/src/index.css`
 - `frontend/src/App.tsx`
 - `frontend/src/main.tsx` - React/Vite bootstrap file.
+- `frontend/src/api.ts` - Helper for API requests.
 - `frontend/src/components/GameCanvas.tsx` - Canvas rendering component.
 - `frontend/src/components/GameHeader.tsx` - Displays title, score, lives.
 - `frontend/src/components/HighScoresPanel.tsx` - Shows leaderboard.
@@ -89,7 +90,7 @@ run_tests.sh
   - [x] 4.3 Add tests for the API endpoints.
   - [x] 4.4 Provide `.env.template` for required environment variables.
 - [ ] 5.0 High Score Integration & Polish
-  - [ ] 5.1 Connect frontend to the score API for submitting and viewing scores.
-  - [ ] 5.2 Add initials entry form and high score table in the UI.
+  - [x] 5.1 Connect frontend to the score API for submitting and viewing scores.
+  - [x] 5.2 Add initials entry form and high score table in the UI.
   - [ ] 5.3 Apply final styling and ensure components match mock design.
   - [ ] 5.4 Verify dev_init.sh runs migrations and starts both servers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 2025-06-03 Added minimal FastAPI/React scaffolding and dev scripts
 2025-06-03 Added pixel font styling and completed layout tasks
 2025-06-03 Implemented basic requestAnimationFrame game loop
+2025-06-03 Added high score API integration on frontend

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,34 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import GameHeader from './components/GameHeader'
 import GameCanvas from './components/GameCanvas'
 import GameFooter from './components/GameFooter'
-import HighScoresPanel from './components/HighScoresPanel'
+import HighScoresPanel, { Score } from './components/HighScoresPanel'
+import { getScores } from './api'
 
 function App() {
+  const [scores, setScores] = useState<Score[]>([])
+
+  const fetchScores = async () => {
+    try {
+      const data = await getScores()
+      setScores(data)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  useEffect(() => {
+    fetchScores()
+  }, [])
+
   return (
     <div className="min-h-screen flex flex-col items-center bg-black text-green-500 font-pixel">
       <GameHeader />
       <div className="flex flex-row w-full max-w-screen-md">
         <GameCanvas />
-        <HighScoresPanel />
+        <HighScoresPanel scores={scores} />
       </div>
-      <GameFooter />
+      <GameFooter onScoreSubmitted={fetchScores} />
     </div>
   )
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,14 @@
+export async function getScores() {
+  const resp = await fetch('/api/scores');
+  if (!resp.ok) throw new Error('Failed to fetch scores');
+  return resp.json();
+}
+
+export async function submitScore(initials: string, score: number) {
+  const params = new URLSearchParams({ initials, score: score.toString() });
+  const resp = await fetch(`/api/scores?${params.toString()}`, {
+    method: 'POST',
+  });
+  if (!resp.ok) throw new Error('Failed to submit score');
+  return resp.json();
+}

--- a/frontend/src/components/GameFooter.tsx
+++ b/frontend/src/components/GameFooter.tsx
@@ -1,7 +1,52 @@
-import React from 'react'
+import React, { useState, FormEvent } from 'react'
+import { submitScore } from '../api'
 
-const GameFooter = () => (
-  <footer className="py-4 text-sm">Use arrow keys to move. Space to shoot.</footer>
-)
+interface Props {
+  onScoreSubmitted: () => void
+}
+
+const GameFooter = ({ onScoreSubmitted }: Props) => {
+  const [initials, setInitials] = useState('')
+  const [score, setScore] = useState(0)
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    try {
+      await submitScore(initials, score)
+      setInitials('')
+      setScore(0)
+      onScoreSubmitted()
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  return (
+    <footer className="py-4 text-sm w-full max-w-screen-md">
+      <form onSubmit={handleSubmit} className="flex gap-2 justify-center">
+        <input
+          value={initials}
+          onChange={(e) => setInitials(e.target.value.toUpperCase())}
+          maxLength={3}
+          placeholder="AAA"
+          className="bg-black border border-green-500 p-1 w-16 text-center"
+        />
+        <input
+          type="number"
+          value={score}
+          onChange={(e) => setScore(parseInt(e.target.value) || 0)}
+          className="bg-black border border-green-500 p-1 w-20 text-right"
+        />
+        <button
+          type="submit"
+          className="border border-green-500 px-2"
+        >
+          Submit
+        </button>
+      </form>
+      <div className="mt-2 text-center">Use arrow keys to move. Space to shoot.</div>
+    </footer>
+  )
+}
 
 export default GameFooter

--- a/frontend/src/components/HighScoresPanel.tsx
+++ b/frontend/src/components/HighScoresPanel.tsx
@@ -1,9 +1,25 @@
 import React from 'react'
 
-const HighScoresPanel = () => (
+export interface Score {
+  initials: string
+  score: number
+}
+
+interface Props {
+  scores: Score[]
+}
+
+const HighScoresPanel = ({ scores }: Props) => (
   <aside className="w-48 p-2 border-l border-green-500">
     <h2 className="text-xl mb-2">High Scores</h2>
-    {/* Scores will be listed here */}
+    <ol className="list-decimal ml-4">
+      {scores.map((s, idx) => (
+        <li key={idx} className="flex justify-between">
+          <span>{s.initials}</span>
+          <span>{s.score}</span>
+        </li>
+      ))}
+    </ol>
   </aside>
 )
 


### PR DESCRIPTION
## Summary
- connect frontend to backend score API
- add high score submission form and leaderboard
- document new API helper
- update tasks

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_683f5a0c148c8331af00d0734fc0dea2