### PR TITLE
Expand tasks for Space Man Pac Invaders

### DIFF
--- a/.project-management/current-prd/tasks-prd-space-man-pac-invaders-expanded.md
+++ b/.project-management/current-prd/tasks-prd-space-man-pac-invaders-expanded.md
@@ -48,7 +48,29 @@ LICENSE
 
 ## Tasks
 - [ ] 1.0 Integrate PostgreSQL database using guidelines in `prd-background/postgres-docs.md`
+  - [ ] 1.1 Add `psycopg2` and migration tooling to `backend/requirements.txt`
+  - [ ] 1.2 Update `backend/app/db.py` to read `DATABASE_URL` from environment variables
+  - [ ] 1.3 Create `.env.template` with database connection placeholders
+  - [ ] 1.4 Configure Alembic in `backend/app/migrations` and generate initial migration for `high_scores`
+  - [ ] 1.5 Document local database setup in `DEVELOPMENT.md`
 - [ ] 2.0 Implement UI per `prd-background/design-mock.html` with React and Tailwind
+  - [ ] 2.1 Import the "Press Start 2P" font and configure Tailwind to use it
+  - [ ] 2.2 Apply mockup classes to `GameHeader`, `GameCanvas`, `HighScoresPanel` and `GameFooter`
+  - [ ] 2.3 Make the layout responsive so the high score panel stacks below the canvas on small screens
+  - [ ] 2.4 Style overlay messages and lives display as shown in the mock
 - [ ] 3.0 Build HTML5 Canvas game logic for Space Man Pac, Invaders, and UFO
+  - [ ] 3.1 Add `mazeLayouts.ts` containing at least three maze layouts
+  - [ ] 3.2 Rotate layouts as the player progresses through levels
+  - [ ] 3.3 Implement Power Pellet frightened mode lasting seven seconds
+  - [ ] 3.4 Add UFO invader logic in `ufo.ts` and integrate with game loop
+  - [ ] 3.5 Show game states for title, get ready, playing, player death and game over
 - [ ] 4.0 Expose high score API endpoints and connect frontend to store/retrieve scores
+  - [ ] 4.1 Ensure `GET /api/scores` returns the top 10 scores from PostgreSQL
+  - [ ] 4.2 Validate input to `POST /api/scores` and return the created record
+  - [ ] 4.3 Write tests for both endpoints in `backend/tests`
+  - [ ] 4.4 Update `frontend/src/api.ts` and components to submit and display scores
+  - [ ] 4.5 Display the high score table on the title and game over screens
 - [ ] 5.0 Update environment scripts and documentation for full local setup
+  - [ ] 5.1 Add PostgreSQL startup and migration commands to `dev_init.sh`
+  - [ ] 5.2 Document the setup process in `DEVELOPMENT.md`
+  - [ ] 5.3 Record new dependencies and setup steps in `CHANGELOG.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 2025-06-03 Implemented core game mechanics, styling polish, and ensured dev_init creates DB tables
 2025-06-03 Archived Space Man Pac Invaders PRD
 2025-06-03 Added expanded PRD for Space Man Pac Invaders
+2025-06-03 Expanded Space Man Pac Invaders tasks with subtasks


### PR DESCRIPTION
## Summary
- expand `tasks-prd-space-man-pac-invaders-expanded.md` with detailed subtasks
- record changelog entry

## Testing
- `flake8`
- `npm run lint` in `frontend`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_683f86d791888331ac1b2f393d721158