### PR TITLE
Implement overlay game states

### DIFF
--- a/.project-management/current-prd/tasks-prd-space-man-pac-invaders-expanded.md
+++ b/.project-management/current-prd/tasks-prd-space-man-pac-invaders-expanded.md
@@ -41,6 +41,7 @@ LICENSE
 ### Existing Files Modified
 - `frontend/src/components/GameHeader.tsx` - Game title and stats display
 - `frontend/src/components/GameCanvas.tsx` - Render multiple mazes and invaders
+- `frontend/src/game/logic.ts` - Canvas game loop and state management
 - `frontend/src/components/HighScoresPanel.tsx` - Score table display
 - `frontend/src/components/GameFooter.tsx` - Score submission form
 - `frontend/src/index.css` - Global styles for Tailwind and custom classes
@@ -61,7 +62,7 @@ LICENSE
   - [x] 1.3 Create `.env.template` with database connection placeholders
   - [x] 1.4 Configure Alembic in `backend/app/migrations` and generate initial migration for `high_scores`
   - [x] 1.5 Document local database setup in `DEVELOPMENT.md`
-- [ ] 2.0 Implement UI per `prd-background/design-mock.html` with React and Tailwind
+- [x] 2.0 Implement UI per `prd-background/design-mock.html` with React and Tailwind
   - [x] 2.1 Import the "Press Start 2P" font and configure Tailwind to use it
   - [x] 2.2 Apply mockup classes to `GameHeader`, `GameCanvas`, `HighScoresPanel` and `GameFooter`
   - [x] 2.3 Make the layout responsive so the high score panel stacks below the canvas on small screens
@@ -71,7 +72,7 @@ LICENSE
   - [ ] 3.2 Rotate layouts as the player progresses through levels
   - [ ] 3.3 Implement Power Pellet frightened mode lasting seven seconds
   - [ ] 3.4 Add UFO invader logic in `ufo.ts` and integrate with game loop
-  - [ ] 3.5 Show game states for title, get ready, playing, player death and game over
+  - [x] 3.5 Show game states for title, get ready, playing, player death and game over
 - [x] 4.0 Expose high score API endpoints and connect frontend to store/retrieve scores
   - [x] 4.1 Ensure `GET /api/scores` returns the top 10 scores from PostgreSQL
   - [x] 4.2 Validate input to `POST /api/scores` and return the created record

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 2025-06-04 Marked completed tasks in PRD
 2025-06-04 Styled UI components and added maze layouts
 2025-06-04 Styled overlay messages and lives icons
+2025-06-04 Implemented game state overlay messages

--- a/frontend/src/components/GameCanvas.tsx
+++ b/frontend/src/components/GameCanvas.tsx
@@ -7,10 +7,11 @@ const GameCanvas = () => {
 
   useEffect(() => {
     const canvas = canvasRef.current
+    const overlay = overlayRef.current
     if (!canvas) return
     const ctx = canvas.getContext('2d')
     if (!ctx) return
-    startGame(ctx)
+    startGame(ctx, overlay ?? undefined)
   }, [])
 
   return (
@@ -18,10 +19,9 @@ const GameCanvas = () => {
       <canvas ref={canvasRef} width={480} height={320} className="bg-black border-2 border-cyan-400 shadow-inner shadow-cyan-400" />
       <div
         ref={overlayRef}
+        style={{ display: 'none' }}
         className="game-canvas-area__overlay-message absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-yellow-300 drop-shadow-[2px_2px_0_#ff00ff] text-2xl text-center z-10"
-      >
-        GET READY!
-      </div>
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- mark UI tasks complete
- add overlay message management to canvas game loop
- wire overlay element to game logic
- update changelog

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_683f9c3147c08331bc6379188905fad8