### PR TITLE
Improve retro UI design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@
 2025-06-04 Styled overlay messages and lives icons
 2025-06-04 Implemented game state overlay messages
 2025-06-04 Implemented maze rotation, power pellet mode and UFO
+2025-06-04 Refined retro design with new CSS and component markup

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,9 +22,9 @@ function App() {
   }, [])
 
   return (
-    <div className="min-h-screen flex flex-col items-center bg-black text-green-500 font-pixel">
+    <div className="game-wrapper" id="spaceManPacInvadersApp">
       <GameHeader score={0} lives={3} />
-      <div className="game-main-content flex flex-col md:flex-row gap-5 w-full max-w-screen-md flex-wrap">
+      <div className="game-main-content">
         <GameCanvas />
         <HighScoresPanel scores={scores} />
       </div>

--- a/frontend/src/components/GameCanvas.tsx
+++ b/frontend/src/components/GameCanvas.tsx
@@ -15,12 +15,13 @@ const GameCanvas = () => {
   }, [])
 
   return (
-    <div className="game-canvas-area relative flex justify-center items-center flex-grow min-w-[320px]">
-      <canvas ref={canvasRef} width={480} height={320} className="bg-black border-2 border-cyan-400 shadow-inner shadow-cyan-400" />
+    <div className="game-canvas-area">
+      <div className="game-canvas-area__placeholder-text">(Game Canvas Area)</div>
+      <canvas ref={canvasRef} width={480} height={320} />
       <div
         ref={overlayRef}
         style={{ display: 'none' }}
-        className="game-canvas-area__overlay-message absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-yellow-300 drop-shadow-[2px_2px_0_#ff00ff] text-2xl text-center z-10"
+        className="game-canvas-area__overlay-message"
       />
     </div>
   )

--- a/frontend/src/components/GameFooter.tsx
+++ b/frontend/src/components/GameFooter.tsx
@@ -22,28 +22,19 @@ const GameFooter = ({ onScoreSubmitted }: Props) => {
   }
 
   return (
-    <footer className="game-footer w-full max-w-screen-md pt-4 border-t-2 border-dashed border-cyan-400 text-center">
-      <form onSubmit={handleSubmit} className="game-footer__initials-form flex gap-2 justify-center mb-2">
-        <label htmlFor="initials" className="sr-only">Initials</label>
+    <footer className="game-footer">
+      <form onSubmit={handleSubmit} className="game-footer__initials-form">
+        <label htmlFor="initials">ENTER INITIALS:</label>
         <input
           id="initials"
           value={initials}
           onChange={(e) => setInitials(e.target.value.toUpperCase())}
           maxLength={3}
-          placeholder="AAA"
-          className="game-footer__initials-input bg-gray-800 border border-green-500 p-1 w-16 text-center font-pixel"
+          className="game-footer__initials-input"
         />
-        <input
-          type="number"
-          value={score}
-          onChange={(e) => setScore(parseInt(e.target.value) || 0)}
-          className="bg-gray-800 border border-green-500 p-1 w-20 text-right"
-        />
-        <button type="submit" className="border border-green-500 px-2">
-          Submit
-        </button>
+        <button type="submit">Submit</button>
       </form>
-      <div className="game-footer__message text-pink-400 min-h-[25px]">Use arrow keys to move. Space to shoot.</div>
+      <div className="game-footer__message">Use arrow keys to move. Space to shoot.</div>
     </footer>
   )
 }

--- a/frontend/src/components/GameHeader.tsx
+++ b/frontend/src/components/GameHeader.tsx
@@ -6,15 +6,15 @@ interface Props {
 }
 
 const GameHeader = ({ score, lives }: Props) => (
-  <header className="game-header w-full max-w-screen-md flex justify-between items-center pb-4 border-b-2 border-dashed border-pink-500">
-    <h1 className="game-header__title text-2xl text-yellow-300 drop-shadow-[2px_2px_0_#ff00ff]">Pac Invaders</h1>
-    <div className="game-header__stats text-cyan-300 text-right flex gap-4">
-      <span className="game-header__stat-item"><span className="label text-gray-300">SCORE:</span> <span className="value text-white">{score}</span></span>
-      <span className="game-header__stat-item flex items-center">
-        <span className="label text-gray-300 mr-1">LIVES:</span>
-        <span className="value flex">
+  <header className="game-header">
+    <h1 className="game-header__title">Pac Invaders</h1>
+    <div className="game-header__stats">
+      <span className="game-header__stat-item"><span className="label">SCORE:</span> <span className="value">{score}</span></span>
+      <span className="game-header__stat-item">
+        <span className="label">LIVES:</span>
+        <span className="value">
           {Array.from({ length: lives }).map((_, i) => (
-            <span key={i} className="life-icon text-yellow-300 mr-1 text-lg">●</span>
+            <span key={i} className="life-icon">●</span>
           ))}
         </span>
       </span>

--- a/frontend/src/components/HighScoresPanel.tsx
+++ b/frontend/src/components/HighScoresPanel.tsx
@@ -10,14 +10,14 @@ interface Props {
 }
 
 const HighScoresPanel = ({ scores }: Props) => (
-  <aside className="high-scores-panel w-72 flex-shrink-0 p-4 bg-[rgba(30,0,20,0.7)] border-2 border-pink-500 flex flex-col">
-    <h2 className="high-scores-panel__title text-lg text-green-400 text-center mb-4 pb-2 border-b border-green-400">HIGH SCORES</h2>
-    <ol className="high-scores-panel__list overflow-y-auto flex-grow">
+  <aside className="high-scores-panel">
+    <h2 className="high-scores-panel__title">HIGH SCORES</h2>
+    <ol className="high-scores-panel__list">
       {scores.map((s, idx) => (
-        <li key={idx} className="high-scores-panel__item flex justify-between text-sm border-b border-dotted border-gray-300 last:border-b-0 py-1">
-          <span className="high-scores-panel__item-rank text-cyan-300 w-6">{idx + 1}.</span>
-          <span className="high-scores-panel__item-initials text-yellow-300 w-12 text-center">{s.initials}</span>
-          <span className="high-scores-panel__item-score text-white flex-grow text-right">{s.score}</span>
+        <li key={idx} className="high-scores-panel__item">
+          <span className="high-scores-panel__item-rank">{idx + 1}.</span>
+          <span className="high-scores-panel__item-initials">{s.initials}</span>
+          <span className="high-scores-panel__item-score">{s.score}</span>
         </li>
       ))}
     </ol>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,7 +5,17 @@
 @tailwind utilities;
 
 body {
-  @apply bg-black text-green-500 font-pixel;
+  font-family: 'Press Start 2P', cursive;
+  background-color: #0A001F;
+  color: #E0E0E0;
+  margin: 0;
+  padding: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  min-height: 100vh;
+  box-sizing: border-box;
+  overflow-y: auto;
 }
 
 canvas {
@@ -13,5 +23,200 @@ canvas {
 }
 
 .life-icon {
-  @apply inline-block mr-1 text-yellow-300;
+  color: #FFFF00;
+  margin-right: 4px;
+  display: inline-block;
+  font-size: 1.2em;
+}
+
+.game-wrapper {
+  width: 100%;
+  max-width: 960px;
+  border: 3px solid #39FF14;
+  background-color: rgba(10, 5, 30, 0.85);
+  padding: 20px;
+  box-shadow: 0 0 20px #39FF14, 0 0 30px #39FF14 inset;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.game-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 15px;
+  border-bottom: 2px dashed #FF00FF;
+}
+
+.game-header__title {
+  font-size: 24px;
+  color: #FFFF00;
+  text-shadow: 2px 2px #FF00FF;
+}
+
+.game-header__stats {
+  font-size: 16px;
+  color: #00FFFF;
+  text-align: right;
+}
+
+.game-header__stat-item {
+  margin-left: 20px;
+  white-space: nowrap;
+}
+
+.game-header__stat-item .label {
+  color: #CCCCCC;
+}
+
+.game-header__stat-item .value {
+  color: #FFFFFF;
+}
+
+.game-main-content {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.game-canvas-area {
+  flex-grow: 1;
+  min-width: 320px;
+  height: 480px;
+  background-color: #000000;
+  border: 2px solid #00FFFF;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #555555;
+  font-size: 20px;
+  box-shadow: 0 0 15px #00FFFF inset;
+  position: relative;
+}
+
+.game-canvas-area__overlay-message {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #FFFF00;
+  font-size: 28px;
+  text-shadow: 2px 2px #FF00FF;
+  z-index: 10;
+  text-align: center;
+}
+
+.high-scores-panel {
+  width: 280px;
+  flex-shrink: 0;
+  padding: 15px;
+  background-color: rgba(30, 0, 20, 0.7);
+  border: 2px solid #FF00FF;
+  display: flex;
+  flex-direction: column;
+}
+
+@media (max-width: 768px) {
+  .game-main-content {
+    flex-direction: column;
+  }
+  .high-scores-panel {
+    width: 100%;
+    margin-top: 20px;
+  }
+  .game-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+  .game-header__stats {
+    width: 100%;
+    text-align: left;
+  }
+  .game-header__stat-item {
+    margin-left: 0;
+    margin-right: 20px;
+    display: inline-block;
+  }
+}
+
+.high-scores-panel__title {
+  font-size: 20px;
+  color: #39FF14;
+  text-align: center;
+  margin-bottom: 15px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #39FF14;
+}
+
+.high-scores-panel__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  overflow-y: auto;
+  flex-grow: 1;
+}
+
+.high-scores-panel__item {
+  display: flex;
+  justify-content: space-between;
+  padding: 6px 2px;
+  font-size: 14px;
+  border-bottom: 1px dotted rgba(224, 224, 224, 0.3);
+}
+
+.high-scores-panel__item:last-child {
+  border-bottom: none;
+}
+
+.high-scores-panel__item-rank {
+  color: #00FFFF;
+  width: 30px;
+}
+
+.high-scores-panel__item-initials {
+  color: #FFFF00;
+  width: 60px;
+  text-align: center;
+}
+
+.high-scores-panel__item-score {
+  color: #FFFFFF;
+  text-align: right;
+  flex-grow: 1;
+}
+
+.game-footer {
+  padding-top: 15px;
+  border-top: 2px dashed #00FFFF;
+  text-align: center;
+}
+
+.game-footer__message {
+  font-size: 18px;
+  color: #FF69B4;
+  margin-bottom: 10px;
+  min-height: 25px;
+}
+
+.game-footer__initials-form label {
+  margin-right: 10px;
+  color: #CCCCCC;
+}
+
+.game-footer__initials-input {
+  font-family: 'Press Start 2P', cursive;
+  background-color: #222222;
+  color: #FFFFFF;
+  border: 2px solid #FFFF00;
+  padding: 8px;
+  font-size: 18px;
+  width: 80px;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.game-footer__initials-input:focus {
+  outline: 2px solid #FF00FF;
 }


### PR DESCRIPTION
## Summary
- implement detailed retro CSS styles and layout
- simplify React components to use the new classes
- update root App wrapper

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_683fa1f3667883319dd352e7a35089cd