### PR TITLE
Fix API proxy for Vite dev server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 2025-06-04 Implemented game state overlay messages
 2025-06-04 Implemented maze rotation, power pellet mode and UFO
 2025-06-04 Refined retro design with new CSS and component markup
+2025-06-04 Fixed API proxy for frontend dev server

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,7 +11,8 @@ This section describes development environment setup and is maintained by the co
    cd frontend
    npm install
    ```
-3. Start the Vite dev server:
+3. Start the Vite dev server (configured to proxy `/api` requests to the
+   backend running on port `8000`):
    ```bash
    npm run dev
    ```

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,5 +5,11 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
   },
 })


### PR DESCRIPTION
## Summary
- configure Vite dev server to proxy `/api` to backend
- document proxy behaviour in development docs
- note change in changelog

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_683fa5ae798c8331be227befd4fe95f7