### PR TITLE
Implement API client and TypeScript types

### DIFF
--- a/.project-management/current-prd/tasks-prd-ai-chat-application.md
+++ b/.project-management/current-prd/tasks-prd-ai-chat-application.md
@@ -106,14 +106,14 @@
   - [ ] 2.8 Configure uvicorn server settings and hot reload
 
 - [ ] 3.0 Frontend React Application Foundation
-  - [ ] 3.1 Set up React 18 with TypeScript and strict mode configuration
-  - [ ] 3.2 Create TypeScript interfaces for Chat, Message, and File types
-  - [ ] 3.3 Implement API service client with fetch wrapper and error handling
+- [ ] 3.1 Set up React 18 with TypeScript and strict mode configuration
+  - [x] 3.2 Create TypeScript interfaces for Chat, Message, and File types
+  - [x] 3.3 Implement API service client with fetch wrapper and error handling
   - [ ] 3.4 Set up React Router for future navigation (if needed)
   - [ ] 3.5 Create custom hooks for chat state management (useChat, useMessages)
   - [ ] 3.6 Implement file utility functions for validation and preview
   - [x] 3.7 Set up global CSS with design system color variables
-  - [ ] 3.8 Configure ESLint and TypeScript for code quality
+  - [x] 3.8 Configure ESLint and TypeScript for code quality
 
 - [ ] 4.0 Chat Management System Implementation
   - [ ] 4.1 Implement backend API endpoints for chat CRUD operations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - 2025-06-04: add initial backend app, config with env vars, dev_init setup, and health endpoint
 - 2025-06-04: add basic frontend structure, chat models, and status endpoint
 - 2025-06-04: configure tailwind color variables and update tasks
+- 2025-06-04: add API client, type interfaces, and updated ESLint config

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,3 +1,7 @@
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+import reactPlugin from 'eslint-plugin-react';
+
 export default [
   {
     files: ['**/*.js', '**/*.jsx'],
@@ -10,4 +14,21 @@ export default [
     },
     rules: {},
   },
-]
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      react: reactPlugin,
+    },
+    rules: {
+      'react/jsx-uses-react': 'off',
+      'react/react-in-jsx-scope': 'off',
+    },
+  },
+];

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,32 @@
+export interface ApiOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: any;
+}
+
+const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+
+async function request<T>(path: string, options: ApiOptions = {}): Promise<T> {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: options.method || 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+    },
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`API error: ${response.status} ${errorText}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export const api = {
+  get: <T>(path: string) => request<T>(path),
+  post: <T>(path: string, body: any) => request<T>(path, { method: 'POST', body }),
+  put: <T>(path: string, body: any) => request<T>(path, { method: 'PUT', body }),
+  delete: <T>(path: string) => request<T>(path, { method: 'DELETE' }),
+};

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -1,0 +1,8 @@
+import type { Message } from './message';
+
+export interface Chat {
+  id: string;
+  title: string;
+  messages: Message[];
+  createdAt: string;
+}

--- a/frontend/src/types/message.ts
+++ b/frontend/src/types/message.ts
@@ -1,0 +1,14 @@
+export interface File {
+  filename: string;
+  contentType: string;
+  url?: string;
+}
+
+export interface Message {
+  id: string;
+  chatId: string;
+  role: 'user' | 'assistant';
+  content: string;
+  file?: File;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- add TypeScript interfaces and API client
- configure ESLint for TS/React
- mark tasks completed

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6840980b68808331a73df64361f32450