### PR TITLE
Implement chat storage service

### DIFF
--- a/.project-management/current-prd/tasks-prd-ai-chat-application.md
+++ b/.project-management/current-prd/tasks-prd-ai-chat-application.md
@@ -38,6 +38,7 @@
 - `backend/services/chat_storage.py` - JSON-based chat persistence service
 - `backend/tests/test_chat_api.py` - Unit tests for chat API endpoints
 - `backend/tests/test_openai_service.py` - Unit tests for OpenAI service
+- `backend/tests/test_chat_storage.py` - Unit tests for chat storage
 - `backend/tests/test_status.py` - Unit test for status endpoint
 - `frontend/src/main.tsx` - React application entry point
 - `frontend/src/App.tsx` - Main application component with layout
@@ -97,7 +98,7 @@
 
 - [ ] 2.0 Backend API Foundation and Core Services
   - [x] 2.1 Create Pydantic models for Chat, Message, and File data structures
-  - [ ] 2.2 Implement chat storage service using JSON file persistence
+  - [x] 2.2 Implement chat storage service using JSON file persistence
   - [ ] 2.3 Create OpenAI service wrapper with error handling and retry logic
   - [ ] 2.4 Set up file service for upload validation and processing
   - [ ] 2.5 Create base API router structure and exception handlers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,5 @@
 - 2025-06-04: add basic frontend structure, chat models, and status endpoint
 - 2025-06-04: configure tailwind color variables and update tasks
 - 2025-06-04: add API client, type interfaces, and updated ESLint config
+- 2025-06-04: mark chat storage service task committed
+- 2025-06-04: add chat storage service and tests

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,0 +1,3 @@
+from .chat_storage import ChatStorage
+
+__all__ = ["ChatStorage"]

--- a/backend/services/chat_storage.py
+++ b/backend/services/chat_storage.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+from typing import List
+
+from backend.models.chat import Chat
+
+
+class ChatStorage:
+    """Persist chats to JSON files in a directory."""
+
+    def __init__(self, data_dir: Path | None = None):
+        self.data_dir = data_dir or Path(__file__).resolve().parent.parent / "data"
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+
+    def _chat_path(self, chat_id: str) -> Path:
+        return self.data_dir / f"{chat_id}.json"
+
+    def save_chat(self, chat: Chat) -> None:
+        """Write chat data to disk."""
+        self._chat_path(chat.id).write_text(chat.json(), encoding="utf-8")
+
+    def load_chat(self, chat_id: str) -> Chat:
+        """Load a chat by id."""
+        data = json.loads(self._chat_path(chat_id).read_text(encoding="utf-8"))
+        return Chat(**data)
+
+    def list_chats(self) -> List[Chat]:
+        """Return all stored chats."""
+        chats: List[Chat] = []
+        for file in self.data_dir.glob("*.json"):
+            data = json.loads(file.read_text(encoding="utf-8"))
+            chats.append(Chat(**data))
+        return chats

--- a/backend/tests/test_chat_storage.py
+++ b/backend/tests/test_chat_storage.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from uuid import uuid4
+
+from backend.models.chat import Chat
+from backend.models.message import Message
+from backend.services.chat_storage import ChatStorage
+
+
+def test_chat_storage(tmp_path: Path) -> None:
+    storage = ChatStorage(data_dir=tmp_path)
+    chat_id = str(uuid4())
+    chat = Chat(id=chat_id, title="test", messages=[
+        Message(id=str(uuid4()), chat_id=chat_id, role="user", content="hi")
+    ])
+    storage.save_chat(chat)
+
+    loaded = storage.load_chat(chat_id)
+    assert loaded.id == chat_id
+    assert loaded.messages[0].content == "hi"
+
+    chats = storage.list_chats()
+    assert len(chats) == 1
+    assert chats[0].id == chat_id


### PR DESCRIPTION
## Summary
- start task for chat storage service
- implement `ChatStorage` for JSON persistence
- add unit tests for chat storage
- record task completion in PRD tasks

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840996611bc83318ec66a4c80128477