### PR TITLE
Implement OpenAI service and configurable uvicorn

### DIFF
--- a/.project-management/current-prd/tasks-prd-ai-chat-application.md
+++ b/.project-management/current-prd/tasks-prd-ai-chat-application.md
@@ -99,12 +99,12 @@
 - [ ] 2.0 Backend API Foundation and Core Services
   - [x] 2.1 Create Pydantic models for Chat, Message, and File data structures
   - [x] 2.2 Implement chat storage service using JSON file persistence
-  - [ ] 2.3 Create OpenAI service wrapper with error handling and retry logic
+  - [x] 2.3 Create OpenAI service wrapper with error handling and retry logic
   - [ ] 2.4 Set up file service for upload validation and processing
   - [x] 2.5 Create base API router structure and exception handlers
   - [x] 2.6 Implement health check and API status endpoints
   - [x] 2.7 Add logging configuration and request/response middleware
-  - [ ] 2.8 Configure uvicorn server settings and hot reload
+  - [x] 2.8 Configure uvicorn server settings and hot reload
 
 - [ ] 3.0 Frontend React Application Foundation
 - [ ] 3.1 Set up React 18 with TypeScript and strict mode configuration
@@ -170,7 +170,7 @@
 
 - [ ] 9.0 Testing and Quality Assurance
   - [ ] 9.1 Write unit tests for all backend API endpoints
-  - [ ] 9.2 Create tests for OpenAI service integration with mocking
+  - [x] 9.2 Create tests for OpenAI service integration with mocking
   - [ ] 9.3 Add frontend component tests using React Testing Library
   - [ ] 9.4 Test custom hooks (useChat, useMessages) with proper mocking
   - [ ] 9.5 Implement integration tests for file upload and processing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - 2025-06-04: mark chat storage service task committed
 - 2025-06-04: add chat storage service and tests
 - 2025-06-04: add base API routers, logging middleware, react router, and custom hooks
+- 2025-06-04: add OpenAI service wrapper and uvicorn config

--- a/backend/main.py
+++ b/backend/main.py
@@ -49,5 +49,15 @@ async def status() -> dict:
 
 
 if __name__ == "__main__":
+    import os
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "8000"))
+    reload = os.getenv("RELOAD", "true").lower() == "true"
+    uvicorn.run(
+        "backend.main:app",
+        host=host,
+        port=port,
+        reload=reload,
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ flake8
 httpx
 python-dotenv
 pydantic-settings
+openai

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,3 +1,4 @@
 from .chat_storage import ChatStorage
+from .openai_service import OpenAIService
 
-__all__ = ["ChatStorage"]
+__all__ = ["ChatStorage", "OpenAIService"]

--- a/backend/services/openai_service.py
+++ b/backend/services/openai_service.py
@@ -1,0 +1,42 @@
+import logging
+import time
+from typing import Any, List
+
+try:
+    import openai
+except ImportError:  # pragma: no cover - openai optional for tests
+    openai = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAIService:
+    """Wrapper around OpenAI ChatCompletion with retry logic."""
+
+    def __init__(self, api_key: str) -> None:
+        if openai is None:
+            raise RuntimeError("openai package is required")
+        openai.api_key = api_key
+        self._client = openai.ChatCompletion
+
+    def chat_completion(
+        self,
+        messages: List[dict],
+        model: str = "gpt-3.5-turbo",
+        retries: int = 3,
+        backoff: float = 1.0,
+    ) -> Any:
+        """Request a chat completion with retries on rate limit errors."""
+        last_error: Exception | None = None
+        for attempt in range(retries):
+            try:
+                return self._client.create(model=model, messages=messages)
+            except (openai.error.RateLimitError,) as exc:  # type: ignore[attr-defined]
+                last_error = exc
+                delay = backoff * (2 ** attempt)
+                logger.warning("Rate limited, retrying in %.1fs", delay)
+                time.sleep(delay)
+            except openai.error.OpenAIError as exc:  # type: ignore[attr-defined]
+                logger.error("OpenAI error: %s", exc)
+                raise
+        raise RuntimeError("OpenAI request failed") from last_error

--- a/backend/tests/test_openai_service.py
+++ b/backend/tests/test_openai_service.py
@@ -1,0 +1,56 @@
+from backend.services.openai_service import OpenAIService
+
+
+class FakeOpenAI:
+    class error:
+        class OpenAIError(Exception):
+            pass
+
+        class RateLimitError(OpenAIError):
+            pass
+
+    class ChatCompletion:
+        def __init__(self, responses):
+            self._responses = iter(responses)
+            self.calls = []
+
+        def create(self, **kwargs):
+            self.calls.append(kwargs)
+            resp = next(self._responses)
+            if isinstance(resp, Exception):
+                raise resp
+            return resp
+
+
+def test_chat_completion_success(monkeypatch):
+    fake = FakeOpenAI()
+    fake_response = {"choices": [{"message": {"content": "hello"}}]}
+    fake.ChatCompletion = FakeOpenAI.ChatCompletion([fake_response])
+    monkeypatch.setattr(
+        "backend.services.openai_service.openai", fake, raising=False
+    )
+
+    service = OpenAIService(api_key="key")
+    result = service.chat_completion([{"role": "user", "content": "hi"}])
+    assert result == fake_response
+    assert fake.ChatCompletion.calls[0]["model"] == "gpt-3.5-turbo"
+
+
+def test_chat_completion_retries(monkeypatch):
+    fake = FakeOpenAI()
+    responses = [
+        FakeOpenAI.error.RateLimitError(),
+        FakeOpenAI.error.RateLimitError(),
+        {"choices": [{"message": {"content": "ok"}}]},
+    ]
+    fake.ChatCompletion = FakeOpenAI.ChatCompletion(responses)
+    monkeypatch.setattr(
+        "backend.services.openai_service.openai", fake, raising=False
+    )
+
+    service = OpenAIService(api_key="key")
+    result = service.chat_completion(
+        [{"role": "user", "content": "hi"}], retries=3, backoff=0
+    )
+    assert result["choices"][0]["message"]["content"] == "ok"
+    assert len(fake.ChatCompletion.calls) == 3

--- a/dev_init.sh
+++ b/dev_init.sh
@@ -11,7 +11,7 @@ source venv/bin/activate
 pip install -r backend/requirements.txt
 
 pushd backend >/dev/null
-uvicorn backend.main:app --reload &
+uvicorn backend.main:app --host "${HOST:-0.0.0.0}" --port "${PORT:-8000}" --reload &
 BACKEND_PID=$!
 popd >/dev/null
 


### PR DESCRIPTION
## Summary
- add OpenAIService wrapper with retry logic
- expose OpenAIService from services package
- support uvicorn config via env vars
- update dev_init to pass host/port values
- add OpenAI requirements
- test OpenAI service
- update tasks

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840a327f3588331ac8043d0bad4c4da