### PR TITLE
Implement message API and tests

### DIFF
--- a/.project-management/current-prd/tasks-prd-ai-chat-application.md
+++ b/.project-management/current-prd/tasks-prd-ai-chat-application.md
@@ -78,6 +78,8 @@
 - `backend/api/chat.py` - Add CRUD chat endpoints
 - `backend/services/chat_storage.py` - Add create, delete, and sorted list
 - `backend/tests/test_chat_api.py` - Tests for chat API endpoints
+- `backend/api/messages.py` - Message creation and list endpoints
+- `backend/tests/test_messages_api.py` - Tests for message API endpoints
 
 ### Notes
 
@@ -131,10 +133,10 @@
   - [ ] 4.8 Create frontend chat history sidebar with active chat highlighting
 
 - [ ] 5.0 Message System with AI Integration
-  - [ ] 5.1 Create message API endpoints for sending and retrieving messages
+  - [c] 5.1 Create message API endpoints for sending and retrieving messages
   - [ ] 5.2 Implement OpenAI GPT integration with proper model selection
   - [ ] 5.3 Add streaming response support for real-time AI responses
-  - [ ] 5.4 Create message persistence in chat JSON files
+  - [c] 5.4 Create message persistence in chat JSON files
   - [ ] 5.5 Implement message display with user/AI distinction
   - [ ] 5.6 Add "AI is thinking" indicators and loading states
   - [ ] 5.7 Handle OpenAI API errors and rate limiting gracefully
@@ -173,7 +175,7 @@
   - [ ] 8.8 Add streaming progress indicators and cancel functionality
 
 - [ ] 9.0 Testing and Quality Assurance
-  - [ ] 9.1 Write unit tests for all backend API endpoints
+  - [c] 9.1 Write unit tests for all backend API endpoints
   - [x] 9.2 Create tests for OpenAI service integration with mocking
   - [ ] 9.3 Add frontend component tests using React Testing Library
   - [ ] 9.4 Test custom hooks (useChat, useMessages) with proper mocking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 - 2025-06-04: add OpenAI service wrapper and uvicorn config
 - 2025-06-04: implement file service and utilities with tests
 - 2025-06-04: add chat CRUD API endpoints with storage and tests
+- 2025-06-04: implement message API with persistence and tests

--- a/backend/api/messages.py
+++ b/backend/api/messages.py
@@ -1,17 +1,38 @@
 """Message API endpoints."""
 
 from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from backend.services.chat_storage import ChatStorage
 
 router = APIRouter(prefix="/messages", tags=["messages"])
 
-
-@router.get("/")
-async def list_messages() -> list:
-    """Placeholder for listing messages."""
-    return []
+_storage = ChatStorage()
 
 
-@router.post("/")
-async def create_message() -> dict:
-    """Placeholder for creating a message."""
-    raise HTTPException(status_code=501, detail="Not implemented")
+class MessageCreate(BaseModel):
+    chat_id: str
+    role: str = "user"
+    content: str
+
+
+@router.get("/{chat_id}")
+async def list_messages(chat_id: str):
+    """List messages for a chat."""
+    try:
+        return _storage.list_messages(chat_id)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Chat not found")
+
+
+@router.post("/", status_code=201)
+async def create_message(payload: MessageCreate):
+    """Create a new message for a chat."""
+    try:
+        return _storage.add_message(
+            chat_id=payload.chat_id,
+            role=payload.role,
+            content=payload.content,
+        )
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Chat not found")

--- a/backend/services/chat_storage.py
+++ b/backend/services/chat_storage.py
@@ -5,6 +5,7 @@ from typing import List
 from uuid import uuid4
 
 from backend.models.chat import Chat
+from backend.models.message import Message
 
 
 class ChatStorage:
@@ -46,3 +47,21 @@ class ChatStorage:
             chats.append(Chat(**data))
         chats.sort(key=lambda c: c.created_at, reverse=True)
         return chats
+
+    def add_message(self, chat_id: str, role: str, content: str) -> Message:
+        """Add a message to a chat and persist it."""
+        chat = self.load_chat(chat_id)
+        message = Message(
+            id=uuid4().hex,
+            chat_id=chat_id,
+            role=role,
+            content=content,
+        )
+        chat.messages.append(message)
+        self.save_chat(chat)
+        return message
+
+    def list_messages(self, chat_id: str) -> List[Message]:
+        """Return all messages for a chat."""
+        chat = self.load_chat(chat_id)
+        return chat.messages

--- a/backend/tests/test_messages_api.py
+++ b/backend/tests/test_messages_api.py
@@ -1,0 +1,35 @@
+from fastapi.testclient import TestClient
+import backend.api.chat as chat_api
+import backend.api.messages as messages_api
+from backend.main import app
+from backend.services.chat_storage import ChatStorage
+
+
+def setup_tmp_storage(tmp_path):
+    storage = ChatStorage(data_dir=tmp_path)
+    chat_api._storage = storage
+    messages_api._storage = storage
+    return TestClient(app)
+
+
+def test_message_crud(tmp_path):
+    client = setup_tmp_storage(tmp_path)
+    chat_resp = client.post("/chats/", json={"title": "chat"})
+    chat_id = chat_resp.json()["id"]
+
+    create = client.post(
+        "/messages/",
+        json={"chat_id": chat_id, "role": "user", "content": "hi"},
+    )
+    assert create.status_code == 201
+    msg_id = create.json()["id"]
+    assert create.json()["content"] == "hi"
+
+    list_resp = client.get(f"/messages/{chat_id}")
+    assert list_resp.status_code == 200
+    messages = list_resp.json()
+    assert len(messages) == 1
+    assert messages[0]["id"] == msg_id
+
+    missing = client.get("/messages/badid")
+    assert missing.status_code == 404


### PR DESCRIPTION
## Summary
- add API endpoints for message CRUD and persistence
- store messages in ChatStorage
- test message API endpoints
- update task list
- document changes in CHANGELOG

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840b5f4d824833197cade7516f1a265