### PR TITLE
Implement first message title

### DIFF
--- a/.project-management/current-prd/tasks-prd-ai-chat-application.md
+++ b/.project-management/current-prd/tasks-prd-ai-chat-application.md
@@ -80,6 +80,8 @@
 - `backend/tests/test_chat_api.py` - Tests for chat API endpoints
 - `backend/api/messages.py` - Message creation and list endpoints
 - `backend/tests/test_messages_api.py` - Tests for message API endpoints
+- `backend/models/chat.py` - Chat data model definition
+- `.project-management/current-prd/tasks-prd-ai-chat-application.md` - Task list for the AI chat feature
 
 ### Notes
 
@@ -128,15 +130,15 @@
   - [x] 4.3 Implement new chat creation with auto-generated titles
   - [ ] 4.4 Add chat loading and switching functionality
   - [x] 4.5 Create chat deletion endpoint and confirmation flow
-  - [ ] 4.6 Implement chat title generation based on first message
+  - [x] 4.6 Implement chat title generation based on first message
   - [ ] 4.7 Add chat metadata (creation date, message count, last activity)
   - [ ] 4.8 Create frontend chat history sidebar with active chat highlighting
 
 - [ ] 5.0 Message System with AI Integration
-  - [c] 5.1 Create message API endpoints for sending and retrieving messages
+  - [x] 5.1 Create message API endpoints for sending and retrieving messages
   - [ ] 5.2 Implement OpenAI GPT integration with proper model selection
   - [ ] 5.3 Add streaming response support for real-time AI responses
-  - [c] 5.4 Create message persistence in chat JSON files
+  - [x] 5.4 Create message persistence in chat JSON files
   - [ ] 5.5 Implement message display with user/AI distinction
   - [ ] 5.6 Add "AI is thinking" indicators and loading states
   - [ ] 5.7 Handle OpenAI API errors and rate limiting gracefully

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 - 2025-06-04: implement file service and utilities with tests
 - 2025-06-04: add chat CRUD API endpoints with storage and tests
 - 2025-06-04: implement message API with persistence and tests
+- 2025-06-04: auto-generate chat title from first message and fix chat model bug

--- a/backend/models/chat.py
+++ b/backend/models/chat.py
@@ -9,5 +9,5 @@ class Chat(BaseModel):
 
     id: str
     title: str
-    messages: List[Message] = []
+    messages: List[Message] = Field(default_factory=list)
     created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/services/chat_storage.py
+++ b/backend/services/chat_storage.py
@@ -51,6 +51,7 @@ class ChatStorage:
     def add_message(self, chat_id: str, role: str, content: str) -> Message:
         """Add a message to a chat and persist it."""
         chat = self.load_chat(chat_id)
+        is_first = len(chat.messages) == 0
         message = Message(
             id=uuid4().hex,
             chat_id=chat_id,
@@ -58,6 +59,8 @@ class ChatStorage:
             content=content,
         )
         chat.messages.append(message)
+        if is_first and chat.title.startswith("Chat "):
+            chat.title = content.split("\n", 1)[0][:40]
         self.save_chat(chat)
         return message
 

--- a/backend/tests/test_messages_api.py
+++ b/backend/tests/test_messages_api.py
@@ -33,3 +33,18 @@ def test_message_crud(tmp_path):
 
     missing = client.get("/messages/badid")
     assert missing.status_code == 404
+
+
+def test_first_message_sets_title(tmp_path):
+    client = setup_tmp_storage(tmp_path)
+    chat_resp = client.post("/chats/", json={})
+    chat_id = chat_resp.json()["id"]
+
+    content = "Hello from the first message"
+    client.post(
+        "/messages/",
+        json={"chat_id": chat_id, "role": "user", "content": content},
+    )
+
+    chat_data = client.get(f"/chats/{chat_id}").json()
+    assert chat_data["title"] == content[:40]


### PR DESCRIPTION
## Summary
- update Chat model messages default
- auto-set chat title from the first message
- test title generation logic
- log completed tasks

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840b770d8548331838c8800c3c1edf7