### PR TITLE
Implement chat metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ venv/
 __pycache__/
 frontend/node_modules/
 frontend/dist/
+backend/data/
 *.pyc
 npm-debug.log*
 .env

--- a/.project-management/current-prd/tasks-prd-ai-chat-application.md
+++ b/.project-management/current-prd/tasks-prd-ai-chat-application.md
@@ -38,7 +38,7 @@
 - `backend/services/chat_storage.py` - JSON-based chat persistence service
 - `backend/tests/test_chat_api.py` - Unit tests for chat API endpoints
 - `backend/tests/test_openai_service.py` - Unit tests for OpenAI service
-- `backend/tests/test_chat_storage.py` - Unit tests for chat storage
+ - `backend/tests/test_chat_storage.py` - Unit tests for chat storage and metadata
 - `backend/tests/test_file_service.py` - Unit tests for file service
 - `backend/tests/test_status.py` - Unit test for status endpoint
 - `backend/tests/test_files_api.py` - Unit test for file API endpoint
@@ -52,7 +52,7 @@
 - `frontend/src/hooks/useChat.ts` - Custom hook for chat state management
 - `frontend/src/hooks/useMessages.ts` - Custom hook for message operations
 - `frontend/src/services/api.ts` - API client for backend communication
-- `frontend/src/types/chat.ts` - TypeScript interfaces for chat data
+- `frontend/src/types/chat.ts` - TypeScript interfaces for chat data with metadata
 - `frontend/src/types/message.ts` - TypeScript interfaces for message data
 - `frontend/src/utils/fileUtils.ts` - File handling utility functions
 - `frontend/src/styles/globals.css` - Global styles and color variables
@@ -77,11 +77,11 @@
 - `frontend/src/styles/globals.css` - Global styles and color variables
 - `frontend/tailwind.config.js` - Tailwind CSS configuration
 - `backend/api/chat.py` - Add CRUD chat endpoints
-- `backend/services/chat_storage.py` - Add create, delete, and sorted list
+- `backend/services/chat_storage.py` - Add create, delete, sorted list, and metadata updates
 - `backend/tests/test_chat_api.py` - Tests for chat API endpoints
 - `backend/api/messages.py` - Message creation and list endpoints
 - `backend/tests/test_messages_api.py` - Tests for message API endpoints
-- `backend/models/chat.py` - Chat data model definition
+- `backend/models/chat.py` - Chat data model with metadata fields
 - `.project-management/current-prd/tasks-prd-ai-chat-application.md` - Task list for the AI chat feature
 
 ### Notes
@@ -132,7 +132,7 @@
   - [ ] 4.4 Add chat loading and switching functionality
   - [x] 4.5 Create chat deletion endpoint and confirmation flow
   - [x] 4.6 Implement chat title generation based on first message
-  - [ ] 4.7 Add chat metadata (creation date, message count, last activity)
+  - [x] 4.7 Add chat metadata (creation date, message count, last activity)
   - [ ] 4.8 Create frontend chat history sidebar with active chat highlighting
 
 - [ ] 5.0 Message System with AI Integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 - 2025-06-04: implement message API with persistence and tests
 - 2025-06-04: auto-generate chat title from first message and fix chat model bug
 - 2025-06-04: add tests for file API endpoint
+- 2025-06-04: add chat metadata fields and tests

--- a/backend/models/chat.py
+++ b/backend/models/chat.py
@@ -11,3 +11,5 @@ class Chat(BaseModel):
     title: str
     messages: List[Message] = Field(default_factory=list)
     created_at: datetime = Field(default_factory=datetime.utcnow)
+    message_count: int = 0
+    last_activity: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/services/chat_storage.py
+++ b/backend/services/chat_storage.py
@@ -59,6 +59,8 @@ class ChatStorage:
             content=content,
         )
         chat.messages.append(message)
+        chat.message_count = len(chat.messages)
+        chat.last_activity = message.created_at
         if is_first and chat.title.startswith("Chat "):
             chat.title = content.split("\n", 1)[0][:40]
         self.save_chat(chat)

--- a/backend/tests/test_chat_api.py
+++ b/backend/tests/test_chat_api.py
@@ -29,7 +29,9 @@ def test_chat_crud(tmp_path):
 
     get_resp = client.get(f"/chats/{id1}")
     assert get_resp.status_code == 200
-    assert get_resp.json()["title"] == "First"
+    data = get_resp.json()
+    assert data["title"] == "First"
+    assert data["message_count"] == 0
 
     del_resp = client.delete(f"/chats/{id1}")
     assert del_resp.status_code == 204

--- a/backend/tests/test_chat_storage.py
+++ b/backend/tests/test_chat_storage.py
@@ -5,11 +5,13 @@ from backend.services.chat_storage import ChatStorage
 def test_chat_storage(tmp_path: Path) -> None:
     storage = ChatStorage(data_dir=tmp_path)
     chat = storage.create_chat(title="test")
-    storage.add_message(chat.id, role="user", content="hi")
+    msg = storage.add_message(chat.id, role="user", content="hi")
 
     loaded = storage.load_chat(chat.id)
     assert loaded.id == chat.id
     assert loaded.messages[0].content == "hi"
+    assert loaded.message_count == 1
+    assert loaded.last_activity == msg.created_at
 
     chats = storage.list_chats()
     assert len(chats) == 1

--- a/backend/tests/test_messages_api.py
+++ b/backend/tests/test_messages_api.py
@@ -25,6 +25,9 @@ def test_message_crud(tmp_path):
     msg_id = create.json()["id"]
     assert create.json()["content"] == "hi"
 
+    chat_data = client.get(f"/chats/{chat_id}").json()
+    assert chat_data["message_count"] == 1
+
     list_resp = client.get(f"/messages/{chat_id}")
     assert list_resp.status_code == 200
     messages = list_resp.json()

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -5,4 +5,6 @@ export interface Chat {
   title: string;
   messages: Message[];
   createdAt: string;
+  messageCount: number;
+  lastActivity: string;
 }


### PR DESCRIPTION
## Summary
- track message count and last activity for each chat
- update chat storage to maintain metadata
- adjust frontend Chat type
- add tests for new metadata
- update ignore list
- mark chat metadata task complete

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840bfb25c688331b8007e68e3daa51b