### PR TITLE
Implement chat loading hook and fix delete endpoint

### DIFF
--- a/.project-management/current-prd/tasks-prd-ai-chat-application.md
+++ b/.project-management/current-prd/tasks-prd-ai-chat-application.md
@@ -129,11 +129,12 @@
   - [x] 4.1 Implement backend API endpoints for chat CRUD operations
   - [x] 4.2 Create chat list retrieval with proper sorting (newest first)
   - [x] 4.3 Implement new chat creation with auto-generated titles
-  - [ ] 4.4 Add chat loading and switching functionality
+  - [x] 4.4 Add chat loading and switching functionality
   - [x] 4.5 Create chat deletion endpoint and confirmation flow
   - [x] 4.6 Implement chat title generation based on first message
   - [x] 4.7 Add chat metadata (creation date, message count, last activity)
   - [ ] 4.8 Create frontend chat history sidebar with active chat highlighting
+  - [x] 4.9 Fix duplicate exception handling in delete chat endpoint
 
 - [ ] 5.0 Message System with AI Integration
   - [x] 5.1 Create message API endpoints for sending and retrieving messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 - 2025-06-04: auto-generate chat title from first message and fix chat model bug
 - 2025-06-04: add tests for file API endpoint
 - 2025-06-04: add chat metadata fields and tests
+- 2025-06-04: add frontend chat loading and fix delete endpoint

--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -51,5 +51,3 @@ async def delete_chat(chat_id: str) -> None:
         get_storage().delete_chat(chat_id)
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail="Chat not found")
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail="Chat not found")

--- a/backend/services/chat_storage.py
+++ b/backend/services/chat_storage.py
@@ -14,13 +14,13 @@ class ChatStorage:
 
     def __init__(self, data_dir: Path | None = None):
         if data_dir is None:
-            # Allow overriding the data directory with an environment variable (useful for testing)
+            # Allow overriding data directory with env var during tests
             test_data_dir = os.environ.get('TEST_DATA_DIR')
             if test_data_dir:
                 data_dir = Path(test_data_dir)
             else:
                 data_dir = Path(__file__).resolve().parent.parent / "data"
-        
+
         self.data_dir = data_dir
         self.data_dir.mkdir(parents=True, exist_ok=True)
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -14,13 +14,13 @@ def isolated_storage():
         # Set environment variable to redirect all storage to temp directory
         original_test_data_dir = os.environ.get('TEST_DATA_DIR')
         os.environ['TEST_DATA_DIR'] = str(tmp_dir)
-        
+
         # Clear any cached storage instances
         import api.chat
         import api.messages
         api.chat._storage = None
         api.messages._storage = None
-        
+
         try:
             yield Path(tmp_dir)
         finally:
@@ -29,7 +29,7 @@ def isolated_storage():
                 os.environ['TEST_DATA_DIR'] = original_test_data_dir
             else:
                 os.environ.pop('TEST_DATA_DIR', None)
-            
+
             # Clear cached storage instances again
             api.chat._storage = None
             api.messages._storage = None

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,39 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import useChat from './hooks/useChat';
+import useMessages from './hooks/useMessages';
 
 function Home() {
+  const { chats, activeChatId, activeChat, selectChat } = useChat();
+  const { messages, loadMessages } = useMessages();
+
+  useEffect(() => {
+    if (activeChatId) {
+      void loadMessages(activeChatId);
+    }
+  }, [activeChatId]);
+
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold">AI Chat Application</h1>
+    <div className="flex">
+      <aside className="w-1/4 border-r p-4">
+        {chats.map(chat => (
+          <button
+            key={chat.id}
+            onClick={() => selectChat(chat.id)}
+            className={`block w-full text-left mb-2 ${chat.id === activeChatId ? 'font-bold' : ''}`}
+          >
+            {chat.title}
+          </button>
+        ))}
+      </aside>
+      <main className="flex-1 p-4">
+        <h1 className="text-2xl font-bold mb-4">{activeChat ? activeChat.title : 'AI Chat Application'}</h1>
+        <ul>
+          {messages.map(m => (
+            <li key={m.id}>{m.content}</li>
+          ))}
+        </ul>
+      </main>
     </div>
   );
 }

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -1,8 +1,36 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Chat } from '../types/chat';
+import { api } from '../services/api';
 
 export default function useChat(initialChats: Chat[] = []) {
   const [chats, setChats] = useState<Chat[]>(initialChats);
+  const [activeChatId, setActiveChatId] = useState<string | null>(null);
+
+  const loadChats = async () => {
+    const data = await api.get<Chat[]>('/chats/');
+    setChats(data);
+    if (data.length && !activeChatId) {
+      setActiveChatId(data[0].id);
+    }
+  };
+
+  const selectChat = (chatId: string) => setActiveChatId(chatId);
+
   const addChat = (chat: Chat) => setChats(prev => [...prev, chat]);
-  return { chats, setChats, addChat };
+
+  useEffect(() => {
+    void loadChats();
+  }, []);
+
+  const activeChat = chats.find(c => c.id === activeChatId) || null;
+
+  return {
+    chats,
+    setChats,
+    addChat,
+    loadChats,
+    activeChatId,
+    activeChat,
+    selectChat,
+  };
 }

--- a/frontend/src/hooks/useMessages.ts
+++ b/frontend/src/hooks/useMessages.ts
@@ -1,8 +1,15 @@
 import { useState } from 'react';
 import type { Message } from '../types/message';
+import { api } from '../services/api';
 
 export default function useMessages(initialMessages: Message[] = []) {
   const [messages, setMessages] = useState<Message[]>(initialMessages);
+
+  const loadMessages = async (chatId: string) => {
+    const data = await api.get<Message[]>(`/messages/${chatId}`);
+    setMessages(data);
+  };
+
   const addMessage = (msg: Message) => setMessages(prev => [...prev, msg]);
-  return { messages, setMessages, addMessage };
+  return { messages, setMessages, addMessage, loadMessages };
 }


### PR DESCRIPTION
## Summary
- support chat list loading and switching
- allow message hooks to load chat messages
- show chats and messages in minimal UI
- remove duplicate FileNotFoundError handler
- clean up storage whitespace
- document changes

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840c2c45ba48331aa459cc60baf2531