### PR TITLE
Implement message timestamp display

### DIFF
--- a/.project-management/current-prd/tasks-prd-ai-chat-application.md
+++ b/.project-management/current-prd/tasks-prd-ai-chat-application.md
@@ -56,6 +56,7 @@
 - `frontend/src/types/message.ts` - TypeScript interfaces for message data
 - `frontend/src/utils/fileUtils.ts` - File handling utility functions
 - `frontend/src/styles/globals.css` - Global styles and color variables
+- `frontend/src/utils/dateUtils.ts` - Timestamp formatting utilities
 - `frontend/index.html` - HTML entry point
 - `frontend/vite.config.ts` - Vite build configuration
 - `frontend/tailwind.config.js` - Tailwind CSS configuration
@@ -125,7 +126,7 @@
   - [x] 3.7 Set up global CSS with design system color variables
   - [x] 3.8 Configure ESLint and TypeScript for code quality
 
-- [ ] 4.0 Chat Management System Implementation
+- [x] 4.0 Chat Management System Implementation
   - [x] 4.1 Implement backend API endpoints for chat CRUD operations
   - [x] 4.2 Create chat list retrieval with proper sorting (newest first)
   - [x] 4.3 Implement new chat creation with auto-generated titles
@@ -144,7 +145,7 @@
   - [x] 5.5 Implement message display with user/AI distinction
   - [x] 5.6 Add "AI is thinking" indicators and loading states
   - [ ] 5.7 Handle OpenAI API errors and rate limiting gracefully
-  - [ ] 5.8 Implement message timestamp and formatting
+  - [x] 5.8 Implement message timestamp and formatting
 
 - [ ] 6.0 File Upload and Processing System
   - [ ] 6.1 Create file upload API endpoint with size and type validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 - 2025-06-04: add chat metadata fields and tests
 - 2025-06-04: add frontend chat loading and fix delete endpoint
 - 2025-06-04: add basic chat UI components and hooks
+- 2025-06-04: add message timestamps in UI and mark chat system complete

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Message } from '../types/message';
+import { formatTimestamp } from '../utils/dateUtils';
 
 interface Props {
   message: Message;
@@ -13,7 +14,10 @@ export default function MessageBubble({ message }: Props) {
         isUser ? 'bg-secondary self-end' : 'bg-accent self-start'
       }`}
     >
-      {message.content}
+      <div className="text-xs text-gray-500 mb-1">
+        {formatTimestamp(message.createdAt)}
+      </div>
+      <div>{message.content}</div>
     </div>
   );
 }

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -1,0 +1,4 @@
+export function formatTimestamp(iso: string): string {
+  const date = new Date(iso);
+  return date.toLocaleString();
+}


### PR DESCRIPTION
## Summary
- mark chat management task complete
- show timestamp on messages using new date utils
- document timestamp feature in tasks

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6840d3d81fa88331952b7f8e28fa795b