### PR TITLE
Implement OpenAI model config

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,4 @@
 # Environment configuration for AI Chat Application
 OPENAI_API_KEY=your-openai-api-key
 ALLOW_ORIGINS=http://localhost:5173
+OPENAI_MODEL=gpt-3.5-turbo

--- a/.project-management/current-prd/tasks-prd-ai-chat-application.md
+++ b/.project-management/current-prd/tasks-prd-ai-chat-application.md
@@ -84,6 +84,10 @@
 - `backend/tests/test_messages_api.py` - Tests for message API endpoints
 - `backend/models/chat.py` - Chat data model with metadata fields
 - `.project-management/current-prd/tasks-prd-ai-chat-application.md` - Task list for the AI chat feature
+- `backend/services/openai_service.py` - OpenAI model configuration and error handling
+- `backend/config.py` - Add OPENAI_MODEL setting
+- `.env.template` - Example environment configuration with model variable
+- `backend/tests/test_openai_service.py` - Unit tests for OpenAI service
 - `backend/api/files.py` - API endpoints for file upload and processing
 - `frontend/src/components/Sidebar.tsx` - Chat history sidebar component
 - `frontend/src/components/ChatInput.tsx` - Message input with file attachment
@@ -144,12 +148,12 @@
 
 - [ ] 5.0 Message System with AI Integration
   - [x] 5.1 Create message API endpoints for sending and retrieving messages
-  - [ ] 5.2 Implement OpenAI GPT integration with proper model selection
+  - [x] 5.2 Implement OpenAI GPT integration with proper model selection
   - [ ] 5.3 Add streaming response support for real-time AI responses
   - [x] 5.4 Create message persistence in chat JSON files
   - [x] 5.5 Implement message display with user/AI distinction
   - [x] 5.6 Add "AI is thinking" indicators and loading states
-  - [ ] 5.7 Handle OpenAI API errors and rate limiting gracefully
+  - [x] 5.7 Handle OpenAI API errors and rate limiting gracefully
   - [x] 5.8 Implement message timestamp and formatting
 
 - [ ] 6.0 File Upload and Processing System
@@ -169,7 +173,7 @@
   - [x] 7.4 Create MessageBubble component with user/AI styling distinction
   - [x] 7.5 Implement ChatInput component with auto-resizing textarea
   - [x] 7.6 Add FileUpload component with paperclip button integration
-  - [ ] 7.7 Apply exact color palette from design mockup (#A4CCD9, #C4E1E6, #EBFFD8)
+  - [x] 7.7 Apply exact color palette from design mockup (#A4CCD9, #C4E1E6, #EBFFD8)
   - [ ] 7.8 Implement responsive design for mobile and desktop views
   - [x] 7.9 Add hover effects and interactive states for all buttons
   - [x] 7.10 Create custom scrollbar styling to match design mockup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@
 - 2025-06-04: implement file upload endpoint and component
     - tests failed: RuntimeError requiring python-multipart
 - 2025-06-04: add button hover states and auto-scroll feature
+- 2025-06-04: add OPENAI model config, improved error handling, and update tasks

--- a/backend/config.py
+++ b/backend/config.py
@@ -10,6 +10,7 @@ load_dotenv()
 
 class Settings(BaseSettings):
     OPENAI_API_KEY: str
+    OPENAI_MODEL: str = "gpt-3.5-turbo"
     ALLOW_ORIGINS: str = "http://localhost:5173"
 
     @validator("OPENAI_API_KEY")

--- a/backend/services/openai_service.py
+++ b/backend/services/openai_service.py
@@ -2,6 +2,8 @@ import logging
 import time
 from typing import Any, List
 
+from config import settings
+
 try:
     import openai
 except ImportError:  # pragma: no cover - openai optional for tests
@@ -13,21 +15,23 @@ logger = logging.getLogger(__name__)
 class OpenAIService:
     """Wrapper around OpenAI ChatCompletion with retry logic."""
 
-    def __init__(self, api_key: str) -> None:
+    def __init__(self, api_key: str, model: str | None = None) -> None:
         if openai is None:
             raise RuntimeError("openai package is required")
         openai.api_key = api_key
         self._client = openai.ChatCompletion
+        self.default_model = model or settings.OPENAI_MODEL
 
     def chat_completion(
         self,
         messages: List[dict],
-        model: str = "gpt-3.5-turbo",
+        model: str | None = None,
         retries: int = 3,
         backoff: float = 1.0,
     ) -> Any:
         """Request a chat completion with retries on rate limit errors."""
         last_error: Exception | None = None
+        model = model or self.default_model
         for attempt in range(retries):
             try:
                 return self._client.create(model=model, messages=messages)
@@ -37,6 +41,8 @@ class OpenAIService:
                 logger.warning("Rate limited, retrying in %.1fs", delay)
                 time.sleep(delay)
             except openai.error.OpenAIError as exc:  # type: ignore[attr-defined]
+                last_error = exc
                 logger.error("OpenAI error: %s", exc)
-                raise
-        raise RuntimeError("OpenAI request failed") from last_error
+                break
+        if last_error:
+            raise RuntimeError("OpenAI request failed") from last_error

--- a/backend/tests/test_openai_service.py
+++ b/backend/tests/test_openai_service.py
@@ -54,3 +54,21 @@ def test_chat_completion_retries(monkeypatch):
     )
     assert result["choices"][0]["message"]["content"] == "ok"
     assert len(fake.ChatCompletion.calls) == 3
+
+
+def test_default_model_from_settings(monkeypatch):
+    fake = FakeOpenAI()
+    fake_response = {"choices": [{"message": {"content": "hello"}}]}
+    fake.ChatCompletion = FakeOpenAI.ChatCompletion([fake_response])
+    monkeypatch.setattr(
+        "backend.services.openai_service.openai", fake, raising=False
+    )
+    monkeypatch.setattr(
+        "backend.services.openai_service.settings.OPENAI_MODEL",
+        "gpt-test",
+        raising=False,
+    )
+
+    service = OpenAIService(api_key="key")
+    service.chat_completion([{"role": "user", "content": "hi"}])
+    assert fake.ChatCompletion.calls[0]["model"] == "gpt-test"


### PR DESCRIPTION
## Summary
- make OPENAI model configurable via environment
- default to OPENAI_MODEL in OpenAIService
- improve error handling when contacting OpenAI
- add tests for OpenAIService
- update task list

## Testing
- `./run_tests.sh`
- `flake8`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840da3318488331b613b4aa2ee2ef00