### PR TITLE
Add tests for custom hooks

### DIFF
--- a/.project-management/current-prd/tasks-prd-ai-chat-application.md
+++ b/.project-management/current-prd/tasks-prd-ai-chat-application.md
@@ -64,6 +64,7 @@
 - `frontend/src/placeholder.js` - Placeholder file to satisfy ESLint
 - `frontend/src/__tests__/components/ChatArea.test.tsx` - Unit tests for chat area
 - `frontend/src/__tests__/hooks/useChat.test.ts` - Unit tests for chat hook
+- `frontend/src/__tests__/hooks/useMessages.test.ts` - Unit tests for messages hook
 
 ### Existing Files Modified
 - `frontend/package.json` - Add React, Vite, Tailwind CSS, and testing dependencies
@@ -193,7 +194,7 @@
   - [x] 9.1 Write unit tests for all backend API endpoints
   - [x] 9.2 Create tests for OpenAI service integration with mocking
   - [x] 9.3 Add frontend component tests using React Testing Library
-  - [ ] 9.4 Test custom hooks (useChat, useMessages) with proper mocking
+  - [x] 9.4 Test custom hooks (useChat, useMessages) with proper mocking
   - [ ] 9.5 Implement integration tests for file upload and processing
   - [ ] 9.6 Add end-to-end tests for complete chat flow
   - [ ] 9.7 Test error handling scenarios and edge cases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@
 - 2025-06-04: add OPENAI model config, improved error handling, and update tasks
 - 2025-06-04: add drag-and-drop upload and responsive layout
 - 2025-06-04: add frontend component tests using vitest
+- 2025-06-04: add unit tests for useChat and useMessages hooks

--- a/frontend/src/__tests__/hooks/useChat.test.ts
+++ b/frontend/src/__tests__/hooks/useChat.test.ts
@@ -1,0 +1,39 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import useChat from '../../hooks/useChat';
+import { api } from '../../services/api';
+
+vi.mock('../../services/api', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+describe('useChat', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads chats on mount', async () => {
+    const chats = [{ id: '1', title: 'Chat', created: '', last_activity: '', message_count: 0 }];
+    (api.get as unknown as any).mockResolvedValue(chats);
+    const { result } = renderHook(() => useChat());
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith('/chats/'));
+    expect(result.current.chats).toEqual(chats);
+    expect(result.current.activeChatId).toBe('1');
+  });
+
+  it('creates chat and sets active', async () => {
+    (api.get as unknown as any).mockResolvedValue([]);
+    const chat = { id: '2', title: 'New', created: '', last_activity: '', message_count: 0 };
+    (api.post as unknown as any).mockResolvedValue(chat);
+    const { result } = renderHook(() => useChat());
+    await waitFor(() => expect(api.get).toHaveBeenCalled());
+    await act(async () => {
+      await result.current.createChat('New');
+    });
+    expect(api.post).toHaveBeenCalledWith('/chats/', { title: 'New' });
+    expect(result.current.chats).toContainEqual(chat);
+    expect(result.current.activeChatId).toBe('2');
+  });
+});

--- a/frontend/src/__tests__/hooks/useMessages.test.ts
+++ b/frontend/src/__tests__/hooks/useMessages.test.ts
@@ -1,0 +1,42 @@
+import { act, renderHook } from '@testing-library/react';
+import useMessages from '../../hooks/useMessages';
+import { api } from '../../services/api';
+
+vi.mock('../../services/api', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+describe('useMessages', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads messages for a chat', async () => {
+    const msgs = [{ id: '1', chat_id: 'c', role: 'user', content: 'hi', created_at: '' }];
+    (api.get as unknown as any).mockResolvedValue(msgs);
+    const { result } = renderHook(() => useMessages());
+    await act(async () => {
+      await result.current.loadMessages('c');
+    });
+    expect(api.get).toHaveBeenCalledWith('/messages/c');
+    expect(result.current.messages).toEqual(msgs);
+  });
+
+  it('sends message and appends to list', async () => {
+    const msg = { id: '2', chat_id: 'c', role: 'user', content: 'hello', created_at: '' };
+    (api.post as unknown as any).mockResolvedValue(msg);
+    const { result } = renderHook(() => useMessages());
+    await act(async () => {
+      await result.current.sendMessage('c', 'hello');
+    });
+    expect(api.post).toHaveBeenCalledWith('/messages/', {
+      chat_id: 'c',
+      role: 'user',
+      content: 'hello',
+    });
+    expect(result.current.messages).toContainEqual(msg);
+  });
+});


### PR DESCRIPTION
## Summary
- add vitest tests for useChat and useMessages hooks
- document new tests in the task list
- mark hook test task complete
- record change in CHANGELOG

## Testing
- `flake8`
- `npm run lint` in `frontend`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840e171db408331b6227d900fa4a704