### PR TITLE
Fix timestamps and add tests

### DIFF
--- a/.project-management/current-prd/tasks-prd-ai-chat-application.md
+++ b/.project-management/current-prd/tasks-prd-ai-chat-application.md
@@ -65,6 +65,7 @@
 - `frontend/src/__tests__/components/ChatArea.test.tsx` - Unit tests for chat area
 - `frontend/src/__tests__/hooks/useChat.test.ts` - Unit tests for chat hook
 - `frontend/src/__tests__/hooks/useMessages.test.ts` - Unit tests for messages hook
+- `frontend/src/__tests__/utils/dateUtils.test.ts` - Unit tests for timestamp formatting utility
 
 ### Existing Files Modified
 - `frontend/package.json` - Add React, Vite, Tailwind CSS, and testing dependencies
@@ -95,6 +96,12 @@
 - `frontend/src/components/FileUpload.tsx` - File upload interface component
 - `frontend/src/components/ChatArea.tsx` - Main chat interface component
 - `frontend/src/App.tsx` - Responsive layout for mobile/desktop
+- `frontend/src/types/message.ts` - Message interface with timestamps in snake_case
+- `frontend/src/types/chat.ts` - Chat interface with timestamps in snake_case
+- `frontend/src/components/MessageBubble.tsx` - Display message timestamps correctly
+- `frontend/src/utils/dateUtils.ts` - Handle invalid timestamps gracefully
+- `frontend/src/__tests__/components/ChatArea.test.tsx` - Updated for new Chat fields
+- `frontend/src/__tests__/hooks/useChat.test.ts` - Updated for new Chat fields
 
 ### Notes
 
@@ -157,7 +164,7 @@
   - [x] 5.6 Add "AI is thinking" indicators and loading states
   - [x] 5.7 Handle OpenAI API errors and rate limiting gracefully
   - [x] 5.8 Implement message timestamp and formatting
-  - [ ] 5.9 Fix Invalid Date display by ensuring all messages and chats have valid timestamp fields and are correctly formatted in the frontend.  Protect from regression with unit tests.
+  - [x] 5.9 Fix Invalid Date display by ensuring all messages and chats have valid timestamp fields and are correctly formatted in the frontend.  Protect from regression with unit tests.
   - [ ] 5.10 Integrate OpenAI response generation in message creation endpoint - modify create_message to call OpenAI service after storing user message, generate AI response, and store assistant message with proper error handling and conversation context
   - [ ] 5.11 Fix file upload integration with messages - modify message creation to accept file attachments, store file references in message JSON, and ensure uploaded files are properly linked to messages instead of being orphaned uploads
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@
 - 2025-06-04: add drag-and-drop upload and responsive layout
 - 2025-06-04: add frontend component tests using vitest
 - 2025-06-04: add unit tests for useChat and useMessages hooks
+- 2025-06-05: fix timestamp display and add date utility tests

--- a/frontend/src/__tests__/components/ChatArea.test.tsx
+++ b/frontend/src/__tests__/components/ChatArea.test.tsx
@@ -27,9 +27,10 @@ describe('ChatArea', () => {
     const chat: Chat = {
       id: '1',
       title: 'Test Chat',
-      created: '',
+      created_at: '',
       last_activity: '',
       message_count: 0,
+      messages: [],
     };
     render(<ChatArea activeChat={chat} />);
     expect(screen.getByRole('heading', { name: 'Test Chat' })).toBeInTheDocument();

--- a/frontend/src/__tests__/hooks/useChat.test.ts
+++ b/frontend/src/__tests__/hooks/useChat.test.ts
@@ -15,7 +15,7 @@ describe('useChat', () => {
   });
 
   it('loads chats on mount', async () => {
-    const chats = [{ id: '1', title: 'Chat', created: '', last_activity: '', message_count: 0 }];
+    const chats = [{ id: '1', title: 'Chat', created_at: '', last_activity: '', message_count: 0, messages: [] }];
     (api.get as unknown as any).mockResolvedValue(chats);
     const { result } = renderHook(() => useChat());
     await waitFor(() => expect(api.get).toHaveBeenCalledWith('/chats/'));
@@ -25,7 +25,7 @@ describe('useChat', () => {
 
   it('creates chat and sets active', async () => {
     (api.get as unknown as any).mockResolvedValue([]);
-    const chat = { id: '2', title: 'New', created: '', last_activity: '', message_count: 0 };
+    const chat = { id: '2', title: 'New', created_at: '', last_activity: '', message_count: 0, messages: [] };
     (api.post as unknown as any).mockResolvedValue(chat);
     const { result } = renderHook(() => useChat());
     await waitFor(() => expect(api.get).toHaveBeenCalled());

--- a/frontend/src/__tests__/utils/dateUtils.test.ts
+++ b/frontend/src/__tests__/utils/dateUtils.test.ts
@@ -1,0 +1,15 @@
+import { formatTimestamp } from '../../utils/dateUtils';
+
+describe('formatTimestamp', () => {
+  it('returns formatted date for valid iso string', () => {
+    const iso = '2024-01-01T00:00:00Z';
+    const formatted = formatTimestamp(iso);
+    expect(formatted).not.toEqual('');
+    expect(formatted).not.toMatch(/Invalid Date/);
+  });
+
+  it('returns empty string for invalid input', () => {
+    const formatted = formatTimestamp(undefined as unknown as string);
+    expect(formatted).toBe('');
+  });
+});

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -15,7 +15,7 @@ export default function MessageBubble({ message }: Props) {
       }`}
     >
       <div className="text-xs text-gray-500 mb-1">
-        {formatTimestamp(message.createdAt)}
+        {formatTimestamp(message.created_at)}
       </div>
       <div>{message.content}</div>
     </div>

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -4,7 +4,7 @@ export interface Chat {
   id: string;
   title: string;
   messages: Message[];
-  createdAt: string;
-  messageCount: number;
-  lastActivity: string;
+  created_at: string;
+  message_count: number;
+  last_activity: string;
 }

--- a/frontend/src/types/message.ts
+++ b/frontend/src/types/message.ts
@@ -6,9 +6,9 @@ export interface File {
 
 export interface Message {
   id: string;
-  chatId: string;
+  chat_id: string;
   role: 'user' | 'assistant';
   content: string;
   file?: File;
-  createdAt: string;
+  created_at: string;
 }

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -1,4 +1,8 @@
-export function formatTimestamp(iso: string): string {
+export function formatTimestamp(iso: string | undefined): string {
+  if (!iso) return '';
   const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
   return date.toLocaleString();
 }


### PR DESCRIPTION
## Summary
- update message and chat types to use snake_case timestamps
- handle invalid timestamps gracefully in date utilities
- adjust MessageBubble to use corrected property
- update unit tests and add date utils tests
- mark timestamp bugfix task complete

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840e6dcb3888331934f528eb9695d4f