### PR TITLE
Fix AI error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@
 - 2025-06-05: fix timestamp display and add date utility tests
 - 2025-06-05: organize uploads into dated subdirectories
 - 2025-06-05: integrate openai responses and add file integration tests
+- 2025-06-05: handle openai failures without returning 500


### PR DESCRIPTION
## Summary
- handle AI response errors gracefully in message creation
- cover failure scenario in message API tests
- document change in CHANGELOG

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840f1423f9c8331a1b2044b6bdc2ccb