### PR TITLE
Fix OpenAI error compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@
 - 2025-06-05: organize uploads into dated subdirectories
 - 2025-06-05: integrate openai responses and add file integration tests
 - 2025-06-05: handle openai failures without returning 500
+- 2025-06-05: fix OpenAI error compatibility for v1

--- a/backend/tests/test_openai_service.py
+++ b/backend/tests/test_openai_service.py
@@ -2,12 +2,17 @@ from backend.services.openai_service import OpenAIService
 
 
 class FakeOpenAI:
-    class error:
-        class OpenAIError(Exception):
-            pass
+    class OpenAIError(Exception):
+        pass
 
-        class RateLimitError(OpenAIError):
-            pass
+    class RateLimitError(OpenAIError):
+        pass
+
+    class error:
+        pass
+
+    error.OpenAIError = OpenAIError
+    error.RateLimitError = RateLimitError
 
     class ChatCompletion:
         def __init__(self, responses):


### PR DESCRIPTION
## Summary
- handle OpenAI v1 error classes gracefully
- update tests for new error structure

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840f38f946c8331b2f0d398ea25f58d