### PR TITLE
Fix OpenAI service usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@
 - 2025-06-05: integrate openai responses and add file integration tests
 - 2025-06-05: handle openai failures without returning 500
 - 2025-06-05: fix OpenAI error compatibility for v1
+- 2025-06-05: update OpenAI service for new API and adjust tests


### PR DESCRIPTION
## Summary
- update OpenAI service to use `OpenAI` client when available
- update service tests for new API interface

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6840f512ceb883318b046a3c5d8d0762