### PR TITLE
Update OpenAI service to use Responses API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,4 @@
 - 2025-06-05: update OpenAI service for new API and adjust tests
 - 2025-06-05: update design mock styling
 - 2025-06-05: apply new UI style and update test config
+- 2025-06-05: switch to Responses API and embed base64 images

--- a/backend/models/message.py
+++ b/backend/models/message.py
@@ -9,6 +9,7 @@ class File(BaseModel):
     filename: str
     content_type: str
     url: Optional[str] = None
+    data_uri: Optional[str] = None
 
 
 class Message(BaseModel):

--- a/backend/services/openai_service.py
+++ b/backend/services/openai_service.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class OpenAIService:
-    """Wrapper around OpenAI ChatCompletion with retry logic."""
+    """Wrapper around OpenAI Responses API with retry logic."""
 
     def __init__(self, api_key: str, model: str | None = None) -> None:
         if openai is None:
@@ -44,7 +44,7 @@ class OpenAIService:
         retries: int = 3,
         backoff: float = 1.0,
     ) -> Any:
-        """Request a chat completion with retries on rate limit errors."""
+        """Request a response with retries on rate limit errors."""
         last_error: Exception | None = None
         model = model or self.default_model
         if hasattr(openai, "error"):
@@ -56,8 +56,12 @@ class OpenAIService:
 
         for attempt in range(retries):
             try:
+                if hasattr(self._client, "responses"):
+                    resp = self._client.responses.create(model=model, input=messages)
+                    resp_dict = self._to_dict(resp)
+                    logger.debug(f"OpenAI response: {resp_dict}")
+                    return resp_dict
                 if hasattr(self._client, "chat"):
-                    # openai>=1.0 client
                     resp = self._client.chat.completions.create(
                         model=model, messages=messages
                     )

--- a/backend/tests/test_file_integration.py
+++ b/backend/tests/test_file_integration.py
@@ -46,4 +46,42 @@ def test_upload_and_attach_file(tmp_path, monkeypatch):
     msgs = client.get(f"/messages/{chat_id}").json()
     assert len(msgs) == 2
     assert msgs[0]["file"]["filename"] == filename
+    assert "data_uri" not in msgs[0]["file"] or msgs[0]["file"]["data_uri"] is None
     assert msgs[1]["role"] == "assistant"
+
+
+def test_image_base64(tmp_path, monkeypatch):
+    files_api._service = FileService(upload_dir=tmp_path)
+    monkeypatch.setattr(messages_api, "OpenAIService", DummyAI)
+    messages_api._openai_service = None
+
+    client = TestClient(app)
+
+    chat_id = client.post("/chats/", json={"title": "img"}).json()["id"]
+
+    import base64
+
+    img_b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8"
+        "AAwMCAO8B9FYAAAAASUVORK5CYII="
+    )
+    file_path = tmp_path / "i.png"
+    file_path.write_bytes(base64.b64decode(img_b64))
+    with file_path.open("rb") as f:
+        resp = client.post("/files/", files={"file": ("i.png", f, "image/png")})
+    assert resp.status_code == 201
+    filename = resp.json()["filename"]
+
+    msg_resp = client.post(
+        "/messages/",
+        json={
+            "chat_id": chat_id,
+            "content": "see",
+            "file": {"filename": filename, "content_type": "image/png"},
+        },
+    )
+    assert msg_resp.status_code == 201
+
+    msgs = client.get(f"/messages/{chat_id}").json()
+    assert msgs[0]["file"]["filename"] == filename
+    assert msgs[0]["file"]["data_uri"].startswith("data:image/png;base64,")

--- a/backend/tests/test_messages_api.py
+++ b/backend/tests/test_messages_api.py
@@ -2,7 +2,19 @@ from fastapi.testclient import TestClient
 from backend.main import app
 
 
-def test_message_crud():
+class DummyAI:
+    def __init__(self, *a, **kw):
+        pass
+
+    def chat_completion(self, messages):
+        return {"output_text": "hello"}
+
+
+def test_message_crud(monkeypatch):
+    import api.messages as messages_api
+    monkeypatch.setattr(messages_api, "OpenAIService", DummyAI)
+    messages_api._openai_service = None
+
     client = TestClient(app)
     chat_resp = client.post("/chats/", json={"title": "chat"})
     chat_id = chat_resp.json()["id"]


### PR DESCRIPTION
## Summary
- update `OpenAIService` to call the OpenAI Responses API
- embed uploaded images as base64 data URIs
- add `data_uri` field to `File` model and persist encoded images
- adjust message creation to attach encoded images and send them to OpenAI
- update and expand tests for new behaviour

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684107a4bc6883318a7f87ee1f9b5a9a