### PR TITLE
Fix AI message history sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@
 - 2025-06-05: update design mock styling
 - 2025-06-05: apply new UI style and update test config
 - 2025-06-05: switch to Responses API and embed base64 images
+- 2025-06-05: refresh messages after sending to include AI responses

--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -28,7 +28,7 @@ export default function ChatArea({ activeChat }: Props) {
     if (!activeChat) return;
     setLoading(true);
     await sendMessage(activeChat.id, content);
-    // placeholder for AI response
+    await loadMessages(activeChat.id);
     setLoading(false);
   };
 
@@ -46,6 +46,7 @@ export default function ChatArea({ activeChat }: Props) {
     };
     
     await sendMessage(activeChat.id, `Uploaded file: ${file.name}`, 'user', fileAttachment);
+    await loadMessages(activeChat.id);
   };
 
   if (!activeChat) {


### PR DESCRIPTION
## Summary
- refresh messages after sending to show AI responses

## Testing
- `./run_tests.sh`
- `flake8`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68410b4bc3088331bbf97dbeb675cb39