### PR TITLE
Implement error handling tests

### DIFF
--- a/.project-management/current-prd/tasks-prd-ai-chat-application.md
+++ b/.project-management/current-prd/tasks-prd-ai-chat-application.md
@@ -209,7 +209,7 @@
   - [x] 9.4 Test custom hooks (useChat, useMessages) with proper mocking
   - [x] 9.5 Implement integration tests for file upload and processing
   - [ ] 9.6 Add end-to-end tests for complete chat flow
-  - [ ] 9.7 Test error handling scenarios and edge cases
+  - [x] 9.7 Test error handling scenarios and edge cases
   - [ ] 9.8 Perform cross-browser compatibility testing
   - [ ] 9.9 Test responsive design on various screen sizes
   - [ ] 9.10 Validate API rate limiting and error recovery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@
 - 2025-06-05: apply new UI style and update test config
 - 2025-06-05: switch to Responses API and embed base64 images
 - 2025-06-05: refresh messages after sending to include AI responses
+- 2025-06-05: add tests for missing chat and oversized file uploads

--- a/backend/api/messages.py
+++ b/backend/api/messages.py
@@ -82,13 +82,16 @@ async def create_message(payload: MessageCreate):
             history: List[Dict[str, object]] = []
             for m in get_storage().list_messages(payload.chat_id):
                 content = m.content
-                # If message has a file with data_uri, ensure content is a list and append the image object
+                # If message has a file with data_uri, ensure content is a list
+                # and append the image object
                 if m.file and m.file.data_uri:
                     image_part = {"type": "input_image", "image_url": m.file.data_uri}
                     if isinstance(content, list):
                         # Only add image if not already present
                         has_image = any(
-                            isinstance(part, dict) and part.get("type") == "input_image" for part in content
+                            isinstance(part, dict)
+                            and part.get("type") == "input_image"
+                            for part in content
                         )
                         if not has_image:
                             content = content + [image_part]
@@ -96,7 +99,8 @@ async def create_message(payload: MessageCreate):
                         content = [content, image_part]
                     else:
                         content = [image_part]
-                # --- FIX: Wrap string parts in {type: "text", text: ...} if content is a list ---
+                # --- FIX: Wrap string parts in {type: "text", text: ...} if
+                # content is a list ---
                 if isinstance(content, list):
                     new_content = []
                     for part in content:
@@ -106,7 +110,8 @@ async def create_message(payload: MessageCreate):
                             new_content.append(part)
                     content = new_content
                 elif isinstance(content, str):
-                    # If content is a string, leave as-is (OpenAI accepts string for pure text)
+                    # If content is a string, leave as-is (OpenAI accepts
+                    # string for pure text)
                     pass
                 history.append({"role": m.role, "content": content})
             try:

--- a/backend/models/message.py
+++ b/backend/models/message.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional, Union, List, Dict, Any
+from typing import Optional, Union, List, Any
 from pydantic import BaseModel, Field
 
 

--- a/backend/tests/test_files_api.py
+++ b/backend/tests/test_files_api.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
 from backend.main import app
+from backend.services.file_service import FileService
 
 client = TestClient(app)
 
@@ -27,3 +28,18 @@ def test_upload_file_invalid_type(tmp_path):
         )
     assert response.status_code == 400
     assert "Unsupported file type" in response.json()["detail"]
+
+
+def test_upload_file_too_large(tmp_path, monkeypatch):
+    import api.files as files_api
+    files_api._service = FileService(upload_dir=tmp_path, max_size=5)
+
+    big_path = tmp_path / "big.txt"
+    big_path.write_bytes(b"0123456789")
+    with big_path.open("rb") as f:
+        response = client.post(
+            "/files/",
+            files={"file": (big_path.name, f, "text/plain")},
+        )
+    assert response.status_code == 400
+    assert "File too large" in response.json()["detail"]

--- a/backend/tests/test_messages_api.py
+++ b/backend/tests/test_messages_api.py
@@ -24,8 +24,9 @@ def test_message_crud(monkeypatch):
         json={"chat_id": chat_id, "role": "user", "content": "hi"},
     )
     assert create.status_code == 201
-    msg_id = create.json()["id"]
-    assert create.json()["content"] == "hi"
+    result = create.json()
+    msg_id = result["user"]["id"]
+    assert result["user"]["content"] == "hi"
 
     chat_data = client.get(f"/chats/{chat_id}").json()
     assert chat_data["message_count"] == 2
@@ -77,7 +78,22 @@ def test_ai_failure_does_not_error(monkeypatch):
         json={"chat_id": chat_id, "role": "user", "content": "hi"},
     )
     assert resp.status_code == 201
-    assert resp.json()["role"] == "user"
+    assert resp.json()["user"]["role"] == "user"
 
     chat_data = client.get(f"/chats/{chat_id}").json()
     assert chat_data["message_count"] == 1
+
+
+def test_create_message_missing_chat(monkeypatch):
+    import api.messages as messages_api
+    monkeypatch.setattr(messages_api, "OpenAIService", DummyAI)
+    messages_api._openai_service = None
+
+    client = TestClient(app)
+
+    resp = client.post(
+        "/messages/",
+        json={"chat_id": "does-not-exist", "role": "user", "content": "hi"},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Chat not found"

--- a/frontend/src/__tests__/hooks/useMessages.test.ts
+++ b/frontend/src/__tests__/hooks/useMessages.test.ts
@@ -27,7 +27,7 @@ describe('useMessages', () => {
 
   it('sends message and appends to list', async () => {
     const msg = { id: '2', chat_id: 'c', role: 'user', content: 'hello', created_at: '' };
-    (api.post as unknown as any).mockResolvedValue(msg);
+    (api.post as unknown as any).mockResolvedValue({ user: msg });
     const { result } = renderHook(() => useMessages());
     await act(async () => {
       await result.current.sendMessage('c', 'hello');


### PR DESCRIPTION
## Summary
- test: add checks for missing chat errors and large file uploads
- update tests for new message response structure
- format long comments for flake8
- document new tests in CHANGELOG
- mark error handling task complete

## Testing
- `flake8`
- `cd frontend && npm run lint`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684115294e688331b8732ce9be8709b4