### PR TITLE
Implement file URL for uploaded message attachments

### DIFF
--- a/.project-management/current-prd/tasks-prd-ai-chat-application.md
+++ b/.project-management/current-prd/tasks-prd-ai-chat-application.md
@@ -83,9 +83,9 @@
 - `backend/api/chat.py` - Add CRUD chat endpoints
 - `backend/services/chat_storage.py` - Add create, delete, sorted list, and metadata updates
 - `backend/tests/test_chat_api.py` - Tests for chat API endpoints
-- `backend/api/messages.py` - Message creation and list endpoints
+- `backend/api/messages.py` - Message creation and list endpoints, add file URL handling
 - `backend/tests/test_messages_api.py` - Tests for message API endpoints
-- `backend/tests/test_file_integration.py` - Integration tests for file uploads and messages
+- `backend/tests/test_file_integration.py` - Integration tests for file uploads and messages, and file URLs
 - `backend/models/chat.py` - Chat data model with metadata fields
 - `.project-management/current-prd/tasks-prd-ai-chat-application.md` - Task list for the AI chat feature
 - `backend/services/openai_service.py` - OpenAI model configuration and error handling
@@ -168,9 +168,9 @@
   - [x] 5.8 Implement message timestamp and formatting
   - [x] 5.9 Fix Invalid Date display by ensuring all messages and chats have valid timestamp fields and are correctly formatted in the frontend.  Protect from regression with unit tests.
   - [x] 5.10 Integrate OpenAI response generation in message creation endpoint - modify create_message to call OpenAI service after storing user message, generate AI response, and store assistant message with proper error handling and conversation context
-  - [ ] 5.11 Fix file upload integration with messages - modify message creation to accept file attachments, store file references in message JSON, and ensure uploaded files are properly linked to messages instead of being orphaned uploads
+  - [x] 5.11 Fix file upload integration with messages - modify message creation to accept file attachments, store file references in message JSON, and ensure uploaded files are properly linked to messages instead of being orphaned uploads
 
-- [ ] 6.0 File Upload and Processing System
+- [x] 6.0 File Upload and Processing System
   - [x] 6.1 Create file upload API endpoint with size and type validation
   - [x] 6.4 Create file storage system with organized directory structure
   - [x] 6.6 Add file attachment UI with drag-and-drop support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@
 - 2025-06-05: switch to Responses API and embed base64 images
 - 2025-06-05: refresh messages after sending to include AI responses
 - 2025-06-05: add tests for missing chat and oversized file uploads
+- 2025-06-05: include file URL in message attachments

--- a/backend/api/messages.py
+++ b/backend/api/messages.py
@@ -64,11 +64,14 @@ async def create_message(payload: MessageCreate):
     """Create a new message for a chat."""
     try:
         file = payload.file
-        if file and file.content_type.startswith("image/"):
+        if file:
             path = files_api.get_service().get_file_path(file.filename)
-            if path.exists():
-                data = file.model_dump(exclude={"data_uri"})
-                file = File(**data, data_uri=_to_data_uri(str(path)))
+            url = f"/files/{file.filename}"
+            data = file.model_dump(exclude={"data_uri", "url"})
+            data_uri = None
+            if file.content_type.startswith("image/") and path.exists():
+                data_uri = _to_data_uri(str(path))
+            file = File(**data, url=url, data_uri=data_uri)
 
         user_msg = get_storage().add_message(
             chat_id=payload.chat_id,

--- a/backend/tests/test_file_integration.py
+++ b/backend/tests/test_file_integration.py
@@ -46,6 +46,7 @@ def test_upload_and_attach_file(tmp_path, monkeypatch):
     msgs = client.get(f"/messages/{chat_id}").json()
     assert len(msgs) == 2
     assert msgs[0]["file"]["filename"] == filename
+    assert msgs[0]["file"]["url"].endswith(filename)
     assert "data_uri" not in msgs[0]["file"] or msgs[0]["file"]["data_uri"] is None
     assert msgs[1]["role"] == "assistant"
 
@@ -84,4 +85,5 @@ def test_image_base64(tmp_path, monkeypatch):
 
     msgs = client.get(f"/messages/{chat_id}").json()
     assert msgs[0]["file"]["filename"] == filename
+    assert msgs[0]["file"]["url"].endswith(filename)
     assert msgs[0]["file"]["data_uri"].startswith("data:image/png;base64,")


### PR DESCRIPTION
## Summary
- update tasks to show file upload fix completed
- include file URL in message attachments
- verify file URLs in integration tests
- document file URL support in CHANGELOG

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68411823ab78833193539ebf8a941775