### PR TITLE
Add streaming endpoint and tests

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,3 +2,4 @@
 OPENAI_API_KEY=your-openai-api-key
 ALLOW_ORIGINS=http://localhost:5173
 OPENAI_MODEL=gpt-3.5-turbo
+FEATURE_STREAMING=false

--- a/.project-management/current-prd/tasks-prd-real-time-streaming.md
+++ b/.project-management/current-prd/tasks-prd-real-time-streaming.md
@@ -11,6 +11,10 @@
 ## Relevant Files
 - backend/api/stream.py - SSE endpoint for streaming responses
 - backend/services/openai_service.py - OpenAI service for chat completions
+- backend/tests/test_stream_endpoint.py - tests for streaming endpoint
+- backend/tests/test_openai_service_stream.py - tests for OpenAI streaming
+- backend/config.py - application configuration with feature flag
+- backend/api/__init__.py - includes stream router when enabled
 - frontend/hooks/useMessages.ts - existing hook for sending messages
 - frontend/components/ChatArea.tsx - chat UI component
 - frontend/package.json - frontend dependencies
@@ -18,6 +22,8 @@
 ### Proposed New Files
 - frontend/hooks/useStream.ts - React hook for consuming SSE streams
 - frontend/hooks/useStream.test.ts - Unit tests for the `useStream` hook
+- backend/tests/test_stream_endpoint.py - backend tests for streaming route
+- backend/tests/test_openai_service_stream.py - backend tests for OpenAI stream
 
 ### Existing Files Modified
 - backend/api/stream.py - add `/stream/` SSE route implementation
@@ -32,17 +38,17 @@
 
 ## Tasks
 - [ ] 1.0 Implement Backend Streaming Endpoint
-  - [ ] 1.1 Define `format_sse` helper in `backend/api/stream.py`.
-  - [ ] 1.2 Add POST `/stream/` route in `backend/api/stream.py` returning `StreamingResponse` with `text/event-stream`.
-  - [ ] 1.3 Create unit tests for `/stream/` endpoint in `tests/test_stream_endpoint.py`.
+  - [x] 1.1 Define `format_sse` helper in `backend/api/stream.py`.
+  - [x] 1.2 Add POST `/stream/` route in `backend/api/stream.py` returning `StreamingResponse` with `text/event-stream`.
+  - [x] 1.3 Create unit tests for `/stream/` endpoint in `tests/test_stream_endpoint.py`.
 
 - [ ] 2.0 Enhance OpenAIService with Streaming Method
-  - [ ] 2.1 Implement `async def chat_completion_stream` in `backend/services/openai_service.py`.
-  - [ ] 2.2 Add unit tests for `chat_completion_stream` in `tests/test_openai_service_stream.py`.
+  - [x] 2.1 Implement `async def chat_completion_stream` in `backend/services/openai_service.py`.
+  - [x] 2.2 Add unit tests for `chat_completion_stream` in `tests/test_openai_service_stream.py`.
 
 - [ ] 3.0 Add Feature Flag and Fallback Logic
-  - [ ] 3.1 Introduce `FEATURE_STREAMING` env var in `config.py`.
-  - [ ] 3.2 Guard `/stream/` route activation in `backend/api/stream.py` with the feature flag.
+  - [x] 3.1 Introduce `FEATURE_STREAMING` env var in `config.py`.
+  - [x] 3.2 Guard `/stream/` route activation in `backend/api/stream.py` with the feature flag.
   - [ ] 3.3 Implement client-side fallback to `/messages/` in `frontend/src/hooks/useStream.ts` when `response.body` is undefined.
 
 - [ ] 4.0 Create Frontend `useStream` Hook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@
 - 2025-06-05: refresh messages after sending to include AI responses
 - 2025-06-05: add tests for missing chat and oversized file uploads
 - 2025-06-05: include file URL in message attachments
+- 2025-06-05: add streaming endpoint and tests

--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -5,11 +5,15 @@ from fastapi import APIRouter
 from api.chat import router as chat_router
 from api.messages import router as message_router
 from api.files import router as file_router
+from api.stream import router as stream_router
+from config import settings
 
 
 api_router = APIRouter()
 api_router.include_router(chat_router)
 api_router.include_router(message_router)
 api_router.include_router(file_router)
+if settings.FEATURE_STREAMING:
+    api_router.include_router(stream_router)
 
 __all__ = ["api_router"]

--- a/backend/api/stream.py
+++ b/backend/api/stream.py
@@ -1,0 +1,74 @@
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+from typing import AsyncGenerator, List
+
+from config import settings
+from services.openai_service import OpenAIService
+from services.chat_storage import ChatStorage
+
+
+router = APIRouter(prefix="/stream", tags=["stream"])
+
+_storage: ChatStorage | None = None
+_openai_service: OpenAIService | None = None
+
+
+def get_storage() -> ChatStorage:
+    global _storage
+    if _storage is None:
+        _storage = ChatStorage()
+    return _storage
+
+
+def get_openai_service() -> OpenAIService:
+    global _openai_service
+    if _openai_service is None:
+        _openai_service = OpenAIService(api_key=settings.OPENAI_API_KEY)
+    return _openai_service
+
+
+def format_sse(data: str, event: str = "message") -> str:
+    return f"event: {event}\ndata: {data}\n\n"
+
+
+class StreamRequest(BaseModel):
+    chat_id: str
+    content: str
+
+
+@router.post("/")
+async def stream(payload: StreamRequest):
+    if not settings.FEATURE_STREAMING:
+        raise HTTPException(status_code=404, detail="Streaming disabled")
+
+    storage = get_storage()
+    storage.add_message(
+        chat_id=payload.chat_id,
+        role="user",
+        content=payload.content,
+    )
+    history: List[dict] = []
+    for m in storage.list_messages(payload.chat_id):
+        content = m.content
+        if m.file and m.file.data_uri:
+            image_part = {
+                "type": "input_image",
+                "image_url": m.file.data_uri,
+            }
+            if isinstance(content, list):
+                content = content + [image_part]
+            else:
+                content = (
+                    [content, image_part]
+                    if isinstance(content, str)
+                    else [image_part]
+                )
+        history.append({"role": m.role, "content": content})
+
+    async def generator() -> AsyncGenerator[str, None]:
+        async for chunk in get_openai_service().chat_completion_stream(history):
+            yield format_sse(str(chunk))
+        yield format_sse("[DONE]", event="done")
+
+    return StreamingResponse(generator(), media_type="text/event-stream")

--- a/backend/config.py
+++ b/backend/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     OPENAI_API_KEY: str
     OPENAI_MODEL: str = "gpt-4.1"
     ALLOW_ORIGINS: str = "http://localhost:5173"
+    FEATURE_STREAMING: bool = False
 
     @validator("OPENAI_API_KEY")
     def validate_key(cls, v: str) -> str:

--- a/backend/services/openai_service.py
+++ b/backend/services/openai_service.py
@@ -83,3 +83,21 @@ class OpenAIService:
                 break
         if last_error:
             raise RuntimeError("OpenAI request failed") from last_error
+
+    async def chat_completion_stream(
+        self,
+        messages: List[dict],
+        model: str | None = None,
+    ):
+        """Yield streaming chat completion chunks."""
+        model = model or self.default_model
+        if hasattr(self._client, "chat"):
+            stream = self._client.chat.completions.create(
+                model=model, messages=messages, stream=True
+            )
+        else:
+            stream = self._client.create(
+                model=model, messages=messages, stream=True
+            )
+        for chunk in stream:
+            yield self._to_dict(chunk)

--- a/backend/tests/test_openai_service_stream.py
+++ b/backend/tests/test_openai_service_stream.py
@@ -1,0 +1,55 @@
+import asyncio
+from backend.services.openai_service import OpenAIService
+
+
+class FakeStream:
+    def __init__(self, responses):
+        self._responses = iter(responses)
+        self.calls = []
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._responses)
+
+
+class FakeOpenAI:
+    class StreamClient:
+        def __init__(self, parent):
+            self.parent = parent
+            self.chat = self
+            self.completions = self
+
+        def create(self, **kwargs):
+            self.parent.calls.append(kwargs)
+            return FakeStream(self.parent._responses)
+
+    def OpenAI(self, api_key=None):
+        return FakeOpenAI.StreamClient(self)
+
+    def __init__(self):
+        self._responses = []
+        self.calls = []
+
+    def set_responses(self, responses):
+        self._responses = responses
+
+
+async def collect(gen):
+    data = []
+    async for chunk in gen:
+        data.append(chunk)
+    return data
+
+
+def test_chat_completion_stream(monkeypatch):
+    fake = FakeOpenAI()
+    fake.set_responses([{"delta": "a"}, {"delta": "b"}])
+    monkeypatch.setattr("backend.services.openai_service.openai", fake, raising=False)
+
+    service = OpenAIService(api_key="key")
+    gen = service.chat_completion_stream([{"role": "user", "content": "hi"}])
+    chunks = asyncio.get_event_loop().run_until_complete(collect(gen))
+    assert chunks == [{"delta": "a"}, {"delta": "b"}]
+    assert fake.calls[0]["model"] == "gpt-3.5-turbo"

--- a/backend/tests/test_stream_endpoint.py
+++ b/backend/tests/test_stream_endpoint.py
@@ -1,0 +1,29 @@
+from backend.main import app
+from backend.api import stream as stream_api
+from fastapi.testclient import TestClient
+
+
+class DummyAI:
+    def __init__(self, *a, **kw):
+        pass
+
+    async def chat_completion_stream(self, messages):
+        for i in range(2):
+            yield {"delta": str(i)}
+
+
+def test_stream_endpoint(monkeypatch):
+    monkeypatch.setattr(stream_api, "OpenAIService", lambda *a, **kw: DummyAI())
+    stream_api._openai_service = None
+    monkeypatch.setattr(stream_api.settings, "FEATURE_STREAMING", True, raising=False)
+    app.include_router(stream_api.router)
+
+    client = TestClient(app)
+    chat_id = client.post("/chats/", json={"title": "chat"}).json()["id"]
+
+    resp = client.post("/stream/", json={"chat_id": chat_id, "content": "hi"})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    body = resp.text
+    assert "delta" in body
+    assert "[DONE]" in body


### PR DESCRIPTION
## Summary
- implement feature flag `FEATURE_STREAMING`
- add `chat_completion_stream` to `OpenAIService`
- create new `/stream/` API with SSE support
- include stream router when enabled
- add backend tests for streaming
- update environment template and tasks

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68411fe9714483319851d757adf4be21