### PR TITLE
Implement frontend streaming hook

### DIFF
--- a/.project-management/current-prd/tasks-prd-real-time-streaming.md
+++ b/.project-management/current-prd/tasks-prd-real-time-streaming.md
@@ -20,8 +20,8 @@
 - frontend/package.json - frontend dependencies
 
 ### Proposed New Files
-- frontend/hooks/useStream.ts - React hook for consuming SSE streams
-- frontend/hooks/useStream.test.ts - Unit tests for the `useStream` hook
+- frontend/src/hooks/useStream.ts - React hook for consuming SSE streams
+- frontend/src/hooks/useStream.test.ts - Unit tests for the `useStream` hook
 - backend/tests/test_stream_endpoint.py - backend tests for streaming route
 - backend/tests/test_openai_service_stream.py - backend tests for OpenAI stream
 
@@ -30,6 +30,8 @@
 - backend/services/openai_service.py - implement `chat_completion_stream` generator
 - frontend/components/ChatArea.tsx - integrate streaming via `useStream`
 - frontend/package.json - add `eventsource-parser` dependency
+- run_tests.sh - ensure dependencies installed for tests
+- frontend/src/services/api.ts - expose API base URL for streaming hook
 
 ### Notes
 - Update `dev_init.sh` to install new frontend and backend dependencies
@@ -37,24 +39,24 @@
 - Ensure CORS/middleware support for `text/event-stream`
 
 ## Tasks
-- [ ] 1.0 Implement Backend Streaming Endpoint
+- [x] 1.0 Implement Backend Streaming Endpoint
   - [x] 1.1 Define `format_sse` helper in `backend/api/stream.py`.
   - [x] 1.2 Add POST `/stream/` route in `backend/api/stream.py` returning `StreamingResponse` with `text/event-stream`.
   - [x] 1.3 Create unit tests for `/stream/` endpoint in `tests/test_stream_endpoint.py`.
 
-- [ ] 2.0 Enhance OpenAIService with Streaming Method
+- [x] 2.0 Enhance OpenAIService with Streaming Method
   - [x] 2.1 Implement `async def chat_completion_stream` in `backend/services/openai_service.py`.
   - [x] 2.2 Add unit tests for `chat_completion_stream` in `tests/test_openai_service_stream.py`.
 
-- [ ] 3.0 Add Feature Flag and Fallback Logic
+- [x] 3.0 Add Feature Flag and Fallback Logic
   - [x] 3.1 Introduce `FEATURE_STREAMING` env var in `config.py`.
   - [x] 3.2 Guard `/stream/` route activation in `backend/api/stream.py` with the feature flag.
-  - [ ] 3.3 Implement client-side fallback to `/messages/` in `frontend/src/hooks/useStream.ts` when `response.body` is undefined.
+  - [x] 3.3 Implement client-side fallback to `/messages/` in `frontend/src/hooks/useStream.ts` when `response.body` is undefined.
 
-- [ ] 4.0 Create Frontend `useStream` Hook
-  - [ ] 4.1 Create `frontend/src/hooks/useStream.ts` with SSE parsing logic using `eventsource-parser`.
-  - [ ] 4.2 Install `eventsource-parser` and update `frontend/package.json`.
-  - [ ] 4.3 Write unit tests in `frontend/src/hooks/useStream.test.ts` using Vitest.
+- [x] 4.0 Create Frontend `useStream` Hook
+  - [x] 4.1 Create `frontend/src/hooks/useStream.ts` with SSE parsing logic using `eventsource-parser`.
+  - [x] 4.2 Install `eventsource-parser` and update `frontend/package.json`.
+  - [x] 4.3 Write unit tests in `frontend/src/hooks/useStream.test.ts` using Vitest.
 
 - [ ] 5.0 Integrate Streaming into `ChatArea` Component
   - [ ] 5.1 Import and use `useStream` in `frontend/src/components/ChatArea.tsx`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,4 @@
 - 2025-06-05: add tests for missing chat and oversized file uploads
 - 2025-06-05: include file URL in message attachments
 - 2025-06-05: add streaming endpoint and tests
+- 2025-06-05: add useStream hook with SSE support and tests

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.3"
+    "react-router-dom": "^6.22.3",
+    "eventsource-parser": "^1.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.4",

--- a/frontend/src/hooks/useStream.test.ts
+++ b/frontend/src/hooks/useStream.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { sendStream } from './useStream';
+
+// Mock fetch
+const fetchMock = vi.fn();
+(global as any).fetch = fetchMock;
+
+const encoder = new TextEncoder();
+
+describe('sendStream', () => {
+  it('falls back to /messages/ when body is undefined', async () => {
+    fetchMock.mockResolvedValueOnce({ body: undefined });
+    fetchMock.mockResolvedValueOnce({});
+    await sendStream('1', 'hi', () => {});
+    expect(fetchMock.mock.calls[1][0]).toContain('/messages/');
+  });
+
+  it('parses stream events', async () => {
+    const chunks = [
+      encoder.encode('event: message\ndata: a\n\n'),
+      encoder.encode('event: done\ndata: [DONE]\n\n'),
+    ];
+    fetchMock.mockResolvedValueOnce({
+      body: {
+        getReader() {
+          let i = 0;
+          return {
+            read() {
+              if (i < chunks.length) {
+                return Promise.resolve({ value: chunks[i++], done: false });
+              }
+              return Promise.resolve({ value: undefined, done: true });
+            },
+          };
+        },
+      },
+    });
+
+    const msgs: string[] = [];
+    await sendStream('1', 'hi', d => msgs.push(d));
+    expect(msgs).toEqual(['a']);
+  });
+});

--- a/frontend/src/hooks/useStream.ts
+++ b/frontend/src/hooks/useStream.ts
@@ -1,0 +1,47 @@
+import { createParser, ParsedEvent, ReconnectInterval } from 'eventsource-parser';
+import { baseUrl } from '../services/api';
+
+export async function sendStream(
+  chatId: string,
+  content: string,
+  onMessage: (data: string) => void,
+  onDone?: () => void,
+): Promise<void> {
+  const resp = await fetch(`${baseUrl}/stream/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chat_id: chatId, content }),
+  });
+
+  if (!resp.body) {
+    // Fallback to standard messages endpoint
+    await fetch(`${baseUrl}/messages/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: chatId, role: 'user', content }),
+    });
+    return;
+  }
+
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  const parser = createParser((event: ParsedEvent | ReconnectInterval) => {
+    if (event.type === 'event') {
+      if (event.event === 'done') {
+        onDone?.();
+      } else {
+        onMessage(event.data);
+      }
+    }
+  });
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    parser.feed(decoder.decode(value));
+  }
+}
+
+export default function useStream() {
+  return { sendStream };
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -4,7 +4,7 @@ export interface ApiOptions {
   body?: any;
 }
 
-const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+export const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000';
 
 async function request<T>(path: string, options: ApiOptions = {}): Promise<T> {
   const response = await fetch(`${baseUrl}${path}`, {

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -14,7 +14,7 @@ pytest backend/tests "$@"
 echo "Running vitest..."
 cd frontend
 # Ensure dependencies are installed before checking vitest
-if ! npm list jsdom >/dev/null 2>&1; then
+if ! npm list jsdom >/dev/null 2>&1 || ! npm list eventsource-parser >/dev/null 2>&1; then
   echo "Installing missing frontend dependencies..."
   npm install
 fi


### PR DESCRIPTION
## Summary
- finish streaming tasks in task list
- add `useStream` React hook for SSE streaming
- add tests for `useStream`
- expose `baseUrl` in API utilities
- install `eventsource-parser` in `package.json`
- auto-install frontend deps in run_tests
- update change log

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh` *(fails: E403 Forbidden to install eventsource-parser)*

------
https://chatgpt.com/codex/tasks/task_e_684121b801c08331b609516b7a3c133d