### PR TITLE
Implement chat list management UI

### DIFF
--- a/.project-management/current-prd/tasks-prd-historical-chat-delete.md
+++ b/.project-management/current-prd/tasks-prd-historical-chat-delete.md
@@ -56,6 +56,7 @@
 
 ### Existing Files Modified
 - `frontend/src/components/Sidebar.tsx` - Update to use new ChatListItem components and handle chat list rendering with management capabilities.
+- `frontend/src/App.tsx` - Pass delete handler prop to Sidebar.
 - `frontend/src/hooks/useChat.ts` - Add delete chat functionality and state management.
 - `frontend/src/services/api.ts` - Add API call for deleting chats.
 - `backend/api/chat.py` - Add DELETE endpoint with active chat validation and proper error handling.
@@ -82,17 +83,17 @@
   - [x] 1.3 Add error handling for non-existent chat IDs and proper HTTP status codes (404, 403, 200)
   - [x] 1.4 Update FastAPI route registration in `backend/main.py` to include the new DELETE endpoint
 
-- [ ] 2.0 Create Frontend Chat Management UI Components
-  - [ ] 2.1 Create `ChatManagementMenu.tsx` component with three-dot icon trigger and dropdown menu containing Delete and Rename options
-  - [ ] 2.2 Implement proper menu positioning, styling, and click-outside-to-close functionality in ChatManagementMenu
-  - [ ] 2.3 Create `ChatListItem.tsx` component with hover effects (background color change) and integration with ChatManagementMenu
-  - [ ] 2.4 Add appropriate icons for Delete (trash can) and Rename (pencil/edit) options using existing icon library or create SVG components
-  - [ ] 2.5 Implement visual state management for hover effects and menu visibility in ChatListItem
+- [x] 2.0 Create Frontend Chat Management UI Components
+  - [x] 2.1 Create `ChatManagementMenu.tsx` component with three-dot icon trigger and dropdown menu containing Delete and Rename options
+  - [x] 2.2 Implement proper menu positioning, styling, and click-outside-to-close functionality in ChatManagementMenu
+  - [x] 2.3 Create `ChatListItem.tsx` component with hover effects (background color change) and integration with ChatManagementMenu
+  - [x] 2.4 Add appropriate icons for Delete (trash can) and Rename (pencil/edit) options using existing icon library or create SVG components
+  - [x] 2.5 Implement visual state management for hover effects and menu visibility in ChatListItem
 
 - [ ] 3.0 Integrate Chat List with Management Capabilities
-  - [ ] 3.1 Refactor `Sidebar.tsx` to use new ChatListItem components instead of direct chat rendering
-  - [ ] 3.2 Pass necessary props (chat data, active chat ID, delete handler) to ChatListItem components
-  - [ ] 3.3 Implement active chat detection logic to disable/hide delete option for currently open chat
+  - [x] 3.1 Refactor `Sidebar.tsx` to use new ChatListItem components instead of direct chat rendering
+  - [x] 3.2 Pass necessary props (chat data, active chat ID, delete handler) to ChatListItem components
+  - [x] 3.3 Implement active chat detection logic to disable/hide delete option for currently open chat
   - [ ] 3.4 Add empty state handling when all chats are deleted (display "No chats available" message)
 
 - [ ] 4.0 Implement Frontend Delete Functionality and State Management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,4 @@
 - 2025-06-05: add useStream hook with SSE support and tests
 - 2025-06-05: integrate streaming into ChatArea with partial UI
 - 2025-06-05: add active chat validation and tests for delete endpoint
+- 2025-06-05: add chat list management components

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,12 @@ function Home() {
     activeChat,
     selectChat,
     createChat,
+    // deleteChat will be implemented later
   } = useChat();
+
+  const deleteChat = (id: string) => {
+    console.log('delete chat', id);
+  };
 
   return (
     <div className="flex flex-col h-screen sm:flex-row">
@@ -20,6 +25,7 @@ function Home() {
         activeChatId={activeChatId}
         onSelect={selectChat}
         onNewChat={() => void createChat()}
+        onDeleteChat={deleteChat}
       />
       <ChatArea activeChat={activeChat} />
     </div>

--- a/frontend/src/components/ChatListItem.tsx
+++ b/frontend/src/components/ChatListItem.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import type { Chat } from '../types/chat';
+import ChatManagementMenu from './ChatManagementMenu';
+
+interface Props {
+  chat: Chat;
+  active: boolean;
+  onSelect: (id: string) => void;
+  onDelete: (id: string) => void;
+}
+
+export default function ChatListItem({ chat, active, onSelect, onDelete }: Props) {
+  const [hover, setHover] = useState(false);
+
+  return (
+    <div
+      className={`flex items-center justify-between px-3 py-2 rounded-lg transition-colors ${
+        active
+          ? 'bg-[var(--color-accent-primary)] text-[var(--color-text-on-accent)]'
+          : 'hover:bg-gray-100 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
+      }`}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+    >
+      <button onClick={() => onSelect(chat.id)} className="flex-1 text-left">
+        {chat.title}
+      </button>
+      {hover && (
+        <ChatManagementMenu
+          onDelete={() => onDelete(chat.id)}
+          disableDelete={active}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ChatManagementMenu.tsx
+++ b/frontend/src/components/ChatManagementMenu.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+interface Props {
+  onDelete: () => void;
+  disableDelete?: boolean;
+}
+
+export default function ChatManagementMenu({ onDelete, disableDelete = false }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (open && ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('click', handleClick);
+    return () => document.removeEventListener('click', handleClick);
+  }, [open]);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        className="p-1 rounded hover:bg-gray-200"
+        onClick={() => setOpen(o => !o)}
+        aria-label="Open chat menu"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+          <circle cx="5" cy="12" r="2" />
+          <circle cx="12" cy="12" r="2" />
+          <circle cx="19" cy="12" r="2" />
+        </svg>
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-1 w-28 bg-white border rounded shadow-md z-10">
+          <button
+            className="flex items-center w-full px-2 py-1 text-left text-sm hover:bg-gray-100 disabled:opacity-50"
+            onClick={() => {
+              setOpen(false);
+              onDelete();
+            }}
+            disabled={disableDelete}
+          >
+            <svg
+              className="mr-2"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <path d="M3 6h18" />
+              <path d="M8 6v12" />
+              <path d="M16 6v12" />
+              <path d="M5 6v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V6" />
+            </svg>
+            Delete
+          </button>
+          <button
+            className="flex items-center w-full px-2 py-1 text-left text-sm text-gray-400 cursor-default"
+          >
+            <svg
+              className="mr-2"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+            >
+              <path d="M4 20h4l10-10-4-4-10 10v4z" />
+            </svg>
+            Rename
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import type { Chat } from '../types/chat';
+import ChatListItem from './ChatListItem';
 
 interface Props {
   chats: Chat[];
   activeChatId: string | null;
   onSelect: (id: string) => void;
   onNewChat: () => void;
+  onDeleteChat: (id: string) => void;
 }
 
-export default function Sidebar({ chats, activeChatId, onSelect, onNewChat }: Props) {
+export default function Sidebar({ chats, activeChatId, onSelect, onNewChat, onDeleteChat }: Props) {
   return (
     <aside className="w-full sm:w-72 bg-[var(--color-bg-sidebar)] border-b sm:border-b-0 sm:border-r border-[var(--color-border-subtle)] p-4 flex flex-col">
       <button
@@ -17,19 +19,15 @@ export default function Sidebar({ chats, activeChatId, onSelect, onNewChat }: Pr
       >
         New Chat
       </button>
-      <div className="overflow-y-auto">
+      <div className="overflow-y-auto space-y-2">
         {chats.map(chat => (
-          <button
+          <ChatListItem
             key={chat.id}
-            onClick={() => onSelect(chat.id)}
-            className={`block w-full text-left mb-2 px-3 py-2 rounded-lg transition-colors font-medium ${
-              chat.id === activeChatId
-                ? 'bg-[var(--color-accent-primary)] text-[var(--color-text-on-accent)]'
-                : 'hover:bg-gray-100 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
-            }`}
-          >
-            {chat.title}
-          </button>
+            chat={chat}
+            active={chat.id === activeChatId}
+            onSelect={onSelect}
+            onDelete={onDeleteChat}
+          />
         ))}
       </div>
     </aside>


### PR DESCRIPTION
## Summary
- create `ChatManagementMenu` and `ChatListItem` components
- refactor `Sidebar` to use new list item component
- wire placeholder delete handler in `App`
- document tasks and add changelog entry

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6841e03188188331984895c8bbfadc69